### PR TITLE
Explicitly call dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,16 +3,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "ougai", "~> 2.0.0"
-gem "pg", "~> 1.0"
-gem "pg_query", "~> 2.1.2"
-gem "pry"
-gem "rake", "~> 13.0"
-gem "rspec", "~> 3.0"
-gem "rubocop", "~> 1.23.0"
-gem "rubocop-packaging", "~> 0.5.1"
-gem "rubocop-performance", "~> 1.12.0"
-gem "rubocop-rake", "~> 0.6.0"
-gem "rubocop-rspec", "~> 2.7.0"
-gem "thor", "~> 1.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,11 @@
 PATH
   remote: .
   specs:
-    pg_online_schema_change (0.1.0)
+    pg_online_schema_change (0.2.0)
+      ougai (~> 2.0.0)
+      pg (~> 1.3.2)
+      pg_query (~> 2.1.3)
+      thor (~> 1.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -9,18 +13,18 @@ GEM
     ast (2.4.2)
     coderay (1.1.3)
     diff-lcs (1.5.0)
-    google-protobuf (3.19.2)
-    google-protobuf (3.19.2-x86_64-linux)
+    google-protobuf (3.19.4)
+    google-protobuf (3.19.4-x86_64-linux)
     method_source (1.0.0)
-    oj (3.13.10)
+    oj (3.13.11)
     ougai (2.0.0)
       oj (~> 3.10)
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
-    pg (1.2.3)
-    pg_query (2.1.2)
-      google-protobuf (>= 3.17.1)
+    pg (1.3.2)
+    pg_query (2.1.3)
+      google-protobuf (>= 3.19.2)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -62,7 +66,7 @@ GEM
     rubocop-rspec (2.7.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
-    thor (1.1.0)
+    thor (1.2.1)
     unicode-display_width (2.1.0)
 
 PLATFORMS
@@ -70,11 +74,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  ougai (~> 2.0.0)
-  pg (~> 1.0)
   pg_online_schema_change!
-  pg_query (~> 2.1.2)
-  pry
+  pry (~> 0.14.1)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.23.0)
@@ -82,7 +83,6 @@ DEPENDENCIES
   rubocop-performance (~> 1.12.0)
   rubocop-rake (~> 0.6.0)
   rubocop-rspec (~> 2.7.0)
-  thor (~> 1.1.0)
 
 BUNDLED WITH
    2.3.3

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Or install it yourself as:
 
     $ gem install pg_online_schema_change
 
+This will include all dependencies accordingly as well. Make sure the following requirements are satisfied.
+
 ## Requirements
 - PostgreSQL 9.6 and later
 - Ruby 2.6 and later

--- a/pg_online_schema_change.gemspec
+++ b/pg_online_schema_change.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors = ["Shayon Mukherjee"]
   spec.email = ["shayonj@gmail.com"]
 
-  spec.summary = "pg-online-schema-change is a tool for schema changes for Postgres tables with minimal locks"
-  spec.description = "pg-online-schema-change (pg-osc) is a tool for making schema changes (any ALTER statements) in Postgres tables with minimal locks, thus helping achieve zero downtime schema changes against production workloads."
+  spec.description = "Easy CLI tool for making non-blocking zero downtime schema changes in PostgreSQL"
+  spec.summary = spec.description
   spec.homepage = "https://github.com/shayonj/pg-osc"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
@@ -31,4 +31,18 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "rubygems_mfa_required" => "true",
   }
+
+  spec.add_runtime_dependency "ougai", "~> 2.0.0"
+  spec.add_runtime_dependency "pg", "~> 1.3.2"
+  spec.add_runtime_dependency "pg_query", "~> 2.1.3"
+  spec.add_runtime_dependency "thor", "~> 1.2.1"
+
+  spec.add_development_dependency "pry", "~> 0.14.1"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 1.23.0"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.1"
+  spec.add_development_dependency "rubocop-performance", "~> 1.12.0"
+  spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.7.0"
 end


### PR DESCRIPTION
This is ensures that the dependencies
are identified in gemspec. So when install
the gem via 'gem install', it will accordingly
install the dependencies as well.

Made a note in the readme

for: https://github.com/shayonj/pg-osc/issues/43

Will close the issue after new release. 