### PR TITLE
Introduce primary key on audit table for ordered reads

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -114,13 +114,13 @@ module PgOnlineSchemaChange
           $$
           BEGIN
             IF ( TG_OP = 'INSERT') THEN
-              INSERT INTO \"#{audit_table}\" select nextval(\'#{audit_table_pk_sequence}\'), 'INSERT', now(), NEW.* ;
+              INSERT INTO \"#{audit_table}\" select nextval(\'#{audit_table_pk_sequence}\'), 'INSERT', clock_timestamp(), NEW.* ;
               RETURN NEW;
             ELSIF ( TG_OP = 'UPDATE') THEN
-              INSERT INTO \"#{audit_table}\" select nextval(\'#{audit_table_pk_sequence}\'), 'UPDATE', now(),  NEW.* ;
+              INSERT INTO \"#{audit_table}\" select nextval(\'#{audit_table_pk_sequence}\'), 'UPDATE', clock_timestamp(),  NEW.* ;
               RETURN NEW;
             ELSIF ( TG_OP = 'DELETE') THEN
-              INSERT INTO \"#{audit_table}\" select nextval(\'#{audit_table_pk_sequence}\'), 'DELETE', now(), OLD.* ;
+              INSERT INTO \"#{audit_table}\" select nextval(\'#{audit_table_pk_sequence}\'), 'DELETE', clock_timestamp(), OLD.* ;
               RETURN NEW;
             END IF;
           END;

--- a/lib/pg_online_schema_change/replay.rb
+++ b/lib/pg_online_schema_change/replay.rb
@@ -28,7 +28,7 @@ module PgOnlineSchemaChange
 
       def rows_to_play(reuse_trasaction = false)
         select_query = <<~SQL
-          SELECT * FROM #{audit_table} ORDER BY #{primary_key} LIMIT #{PULL_BATCH_COUNT};
+          SELECT * FROM #{audit_table} ORDER BY #{audit_table_pk} LIMIT #{PULL_BATCH_COUNT};
         SQL
 
         rows = []
@@ -38,7 +38,7 @@ module PgOnlineSchemaChange
       end
 
       def reserved_columns
-        @reserved_columns ||= ["trigger_time", operation_type_column]
+        @reserved_columns ||= ["trigger_time", operation_type_column, audit_table_pk]
       end
 
       def play!(rows, reuse_trasaction = false)

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -110,13 +110,13 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
         $$
         BEGIN
           IF ( TG_OP = 'INSERT') THEN
-            INSERT INTO "#{described_class.audit_table}" select nextval(\'#{described_class.audit_table_pk_sequence}\'), 'INSERT', now(), NEW.* ;
+            INSERT INTO "#{described_class.audit_table}" select nextval(\'#{described_class.audit_table_pk_sequence}\'), 'INSERT', clock_timestamp(), NEW.* ;
             RETURN NEW;
           ELSIF ( TG_OP = 'UPDATE') THEN
-            INSERT INTO "#{described_class.audit_table}" select nextval(\'#{described_class.audit_table_pk_sequence}\'), 'UPDATE', now(),  NEW.* ;
+            INSERT INTO "#{described_class.audit_table}" select nextval(\'#{described_class.audit_table_pk_sequence}\'), 'UPDATE', clock_timestamp(),  NEW.* ;
             RETURN NEW;
           ELSIF ( TG_OP = 'DELETE') THEN
-            INSERT INTO "#{described_class.audit_table}" select nextval(\'#{described_class.audit_table_pk_sequence}\'), 'DELETE', now(), OLD.* ;
+            INSERT INTO "#{described_class.audit_table}" select nextval(\'#{described_class.audit_table_pk_sequence}\'), 'DELETE', clock_timestamp(), OLD.* ;
             RETURN NEW;
           END IF;
         END;
@@ -181,10 +181,10 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
       described_class.setup_trigger!
       query = <<~SQL
         INSERT INTO "sellers"("name", "createdOn", "last_login")
-        VALUES('local shop', 'now()', 'now()');
+        VALUES('local shop', clock_timestamp(), clock_timestamp());
 
         INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
-        VALUES(1, 1, 'jamesbond', '007', 'james@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
+        VALUES(1, 1, 'jamesbond', '007', 'james@bond.com', clock_timestamp(), clock_timestamp()) RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
 
         UPDATE books SET username = 'bondjames'
         WHERE user_id='1';
@@ -400,7 +400,7 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
       # to audit table
       query = <<~SQL
         INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
-        VALUES(1, 1, 'jamesbond', '007', 'james@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
+        VALUES(1, 1, 'jamesbond', '007', 'james@bond.com', clock_timestamp(), clock_timestamp()) RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
       SQL
       PgOnlineSchemaChange::Query.run(client.connection, query)
 

--- a/spec/lib/replay_spec.rb
+++ b/spec/lib/replay_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe PgOnlineSchemaChange::Replay do
         # Add an entry for the trigger
         query = <<~SQL
           INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
-          VALUES(10, 1, 'jamesbond10 "''i am bond 🚀''"', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
+          VALUES(10, 1, 'jamesbond10 "''i am bond 🚀''"', '0010', 'james10@bond.com', clock_timestamp(), clock_timestamp()) RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
 
           INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
-          VALUES(11, 1, 'jamesbond11 "''i am bond 🚀''"', '0011', 'james11@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
+          VALUES(11, 1, 'jamesbond11 "''i am bond 🚀''"', '0011', 'james11@bond.com', clock_timestamp(), clock_timestamp()) RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
         SQL
         PgOnlineSchemaChange::Query.run(client.connection, query)
 
@@ -239,7 +239,7 @@ RSpec.describe PgOnlineSchemaChange::Replay do
         # Add an entry for the trigger
         query = <<~SQL
           INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
-          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
+          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', clock_timestamp(), clock_timestamp()) RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
         SQL
         PgOnlineSchemaChange::Query.run(client.connection, query)
 
@@ -384,7 +384,7 @@ RSpec.describe PgOnlineSchemaChange::Replay do
         # Add an entry for the trigger
         query = <<~SQL
           INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
-          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', 'now()', 'now()') RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
+          VALUES(10, 1, 'jamesbond10', '0010', 'james10@bond.com', clock_timestamp(), clock_timestamp()) RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
         SQL
         PgOnlineSchemaChange::Query.run(client.connection, query)
 

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -70,13 +70,13 @@ module DatabaseHelpers
     client ||= PgOnlineSchemaChange::Client.new(client_options)
     query = <<~SQL
       INSERT INTO "#{schema}"."sellers"("name", "createdOn", "last_login")
-      VALUES('local shop', 'now()', 'now()');
+      VALUES('local shop', clock_timestamp(), clock_timestamp());
 
       INSERT INTO "#{schema}"."books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
       VALUES
-        (2, 1, 'jamesbond2', '007', 'james1@bond.com', 'now()', 'now()'),
-        (3, 1, 'jamesbond3', '008', 'james2@bond.com', 'now()', 'now()'),
-        (4, 1, 'jamesbond4', '009', 'james3@bond.com', 'now()', 'now()');
+        (2, 1, 'jamesbond2', '007', 'james1@bond.com', clock_timestamp(), clock_timestamp()),
+        (3, 1, 'jamesbond3', '008', 'james2@bond.com', clock_timestamp(), clock_timestamp()),
+        (4, 1, 'jamesbond4', '009', 'james3@bond.com', clock_timestamp(), clock_timestamp());
     SQL
     PgOnlineSchemaChange::Query.run(client.connection, query)
   end


### PR DESCRIPTION
This ensures that all items added to audit table
will be read in the order they came, using the new primary key.

Using the old primary key has edge case if updates happened on the
same row and re-purposing the same primary key will lead to un-ordered
behavior

fixes https://github.com/shayonj/pg-osc/issues/48