### PR TITLE
Abstract assertions into a helper function

### DIFF
--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -113,13 +113,12 @@ RSpec.describe PgOnlineSchemaChange::Query do
       expect(client.connection).to receive(:async_exec).with("SELECT 'FooBar' as result").and_call_original
       expect(client.connection).to receive(:async_exec).with("COMMIT;").and_call_original
 
-      rows = []
-      described_class.run(client.connection, query) do |result|
-        rows = result.map { |r| r }
-      end
-
-      expect(rows.count).to eq(1)
-      expect(rows[0]).to eq({ "result" => "FooBar" })
+      expect_query_result(connection: client.connection, query: query, assertions: [
+        {
+          count: 1,
+          data: [{ "result" => "FooBar" }],
+        },
+      ])
     end
 
     it "returns the alter query successfully" do

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -85,4 +85,18 @@ module DatabaseHelpers
     client ||= PgOnlineSchemaChange::Client.new(client_options)
     PgOnlineSchemaChange::Query.run(client.connection, "DROP SCHEMA IF EXISTS #{schema} CASCADE;")
   end
+
+  def expect_query_result(connection:, query:, assertions:)
+    rows = []
+    PgOnlineSchemaChange::Query.run(connection, query) do |result|
+      rows = result.map { |row| row }
+    end
+
+    assertions.each do |obj|
+      expect(rows.count).to eq(obj[:count])
+      expect(rows).to include(include(obj[:data][0])) if obj[:data]
+    end
+
+    rows
+  end
 end


### PR DESCRIPTION
This refactors tests a bit to abstract
the common operation of running a querying
and asserting the outcome into a function.
This way the callers are bit clean, easy to work
with and more deterministic