### PR TITLE
Reuse existing transaction open for reading table columns

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pg_online_schema_change (0.3.0)
+    pg_online_schema_change (0.4.0)
       ougai (~> 2.0.0)
       pg (~> 1.3.2)
       pg_query (~> 2.1.3)
@@ -14,7 +14,6 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.5.0)
     google-protobuf (3.19.4)
-    google-protobuf (3.19.4-x86_64-linux)
     method_source (1.0.0)
     oj (3.13.11)
     ougai (2.0.0)

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -204,7 +204,7 @@ module PgOnlineSchemaChange
           return Query.run(client.connection, query, true)
         end
 
-        sql = Query.copy_data_statement(client, shadow_table)
+        sql = Query.copy_data_statement(client, shadow_table, true)
         Query.run(client.connection, sql, true)
       ensure
         Query.run(client.connection, "COMMIT;") # commit the serializable transaction


### PR DESCRIPTION
This way it won't begin/commit any existing
transaction and re-use existing transaction
that will next copy data statements.

Caught this on 8k+ commits/s. Doesn't
slow down below it