### PR TITLE
Introduce configurable PULL_BATCH_COUNT and DELTA_COUNT

### DIFF
--- a/docs/load-test.md
+++ b/docs/load-test.md
@@ -42,6 +42,8 @@ bundle exec bin/pg-online-schema-change perform \
 -p 25061
 -h "..." \
 -u "..." \
+--pull-batch-count 2000 \
+--delta-count 200
 ```
 
 ## Outcome
@@ -133,6 +135,4 @@ NOTICE:  table "pgosc_st_pgbench_accounts_714a8b" does not exist, skipping
 
 ## Conclusion
 
-By tweaking `PULL_BATCH_COUNT` to `2000` (replay 2k rows at once) and `DELTA_COUNT` to `200` (time to swap when remaining rows is <200), `pg-osc` was able to perform the schema change with no impact within very quick time. Depending on the database size and load on the table, you can further tune them to achieve desired impact. At some point this is going to plateau - I can imagine the replay factor not working quite well for say 100k commits/s workloads. So, YMMV.
-
-`PULL_BATCH_COUNT` and `DELTA_COUNT` aren't configurable via CLI yet, but they will soon be.
+By tweaking `--pull-batch-count` to `2000` (replay 2k rows at once) and `--delta-count` to `200` (time to swap when remaining rows is <200), `pg-osc` was able to perform the schema change with no impact within very quick time. Depending on the database size and load on the table, you can further tune them to achieve desired impact. At some point this is going to plateau - I can imagine the replay factor not working quite well for say 100k commits/s workloads. So, YMMV.

--- a/lib/pg_online_schema_change.rb
+++ b/lib/pg_online_schema_change.rb
@@ -6,12 +6,12 @@ require "ougai"
 require "pg_online_schema_change/version"
 require "pg_online_schema_change/helper"
 require "pg_online_schema_change/functions"
-require "pg_online_schema_change/cli"
 require "pg_online_schema_change/client"
 require "pg_online_schema_change/query"
 require "pg_online_schema_change/store"
 require "pg_online_schema_change/replay"
 require "pg_online_schema_change/orchestrate"
+require "pg_online_schema_change/cli"
 
 module PgOnlineSchemaChange
   class Error < StandardError; end

--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -5,7 +5,7 @@ require "pg"
 module PgOnlineSchemaChange
   class Client
     attr_accessor :alter_statement, :schema, :dbname, :host, :username, :port, :password, :connection, :table, :drop,
-                  :kill_backends, :wait_time_for_lock, :copy_statement
+                  :kill_backends, :wait_time_for_lock, :copy_statement, :pull_batch_count, :delta_count
 
     def initialize(options)
       @alter_statement = options.alter_statement
@@ -18,6 +18,8 @@ module PgOnlineSchemaChange
       @drop = options.drop
       @kill_backends = options.kill_backends
       @wait_time_for_lock = options.wait_time_for_lock
+      @pull_batch_count = options.pull_batch_count
+      @delta_count = options.delta_count
 
       handle_copy_statement(options.copy_statement)
       handle_validations

--- a/lib/pg_online_schema_change/replay.rb
+++ b/lib/pg_online_schema_change/replay.rb
@@ -7,9 +7,6 @@ module PgOnlineSchemaChange
     extend Helper
 
     class << self
-      PULL_BATCH_COUNT = 1000
-      DELTA_COUNT = 20
-
       # This, picks PULL_BATCH_COUNT rows by primary key from audit_table,
       # replays it on the shadow_table. Once the batch is done,
       # it them deletes those PULL_BATCH_COUNT rows from audit_table. Then, pull another batch,
@@ -20,7 +17,7 @@ module PgOnlineSchemaChange
         loop do
           rows = rows_to_play
 
-          raise CountBelowDelta if rows.count <= DELTA_COUNT
+          raise CountBelowDelta if rows.count <= client.delta_count
 
           play!(rows)
         end
@@ -28,7 +25,7 @@ module PgOnlineSchemaChange
 
       def rows_to_play(reuse_trasaction = false)
         select_query = <<~SQL
-          SELECT * FROM #{audit_table} ORDER BY #{audit_table_pk} LIMIT #{PULL_BATCH_COUNT};
+          SELECT * FROM #{audit_table} ORDER BY #{audit_table_pk} LIMIT #{client.pull_batch_count};
         SQL
 
         rows = []

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe PgOnlineSchemaChange::Client do
     expect(client.table).to eq("books")
     expect(client.drop).to eq(false)
     expect(client.copy_statement).to eq(nil)
+    expect(client.delta_count).to eq(20)
+    expect(client.pull_batch_count).to eq(1000)
   end
 
   it "raises error query is not ALTER" do

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -17,6 +17,8 @@ module DatabaseHelpers
       drop: false,
       kill_backends: false,
       wait_time_for_lock: 5,
+      delta_count: 20,
+      pull_batch_count: 1000,
       copy_statement: "",
     }
     Struct.new(*options.keys).new(*options.values)


### PR DESCRIPTION
On tables with high volume workloads,
having the ability to tune PULL_BATCH_COUNT
and DELTA_COUNT is nice for faster catchup and swap.

The default values are 1000 and 20 respectively. Which means,
in one pass pg-osc will replay 1000 rows and if the count is <20
then it will perform the swap and replay.

By introducing new cli flags (`--pull-batch-count`, `--delta-count`),
these figures can be tuned further

Fixes: https://github.com/shayonj/pg-osc/issues/21