### PR TITLE
Delete items by audit table PK when replaying

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pg_online_schema_change (0.4.0)
+    pg_online_schema_change (0.5.0)
       ougai (~> 2.0.0)
       pg (~> 1.3.2)
       pg_query (~> 2.1.3)

--- a/lib/pg_online_schema_change/replay.rb
+++ b/lib/pg_online_schema_change/replay.rb
@@ -87,7 +87,7 @@ module PgOnlineSchemaChange
             SQL
             to_be_replayed << sql
 
-            to_be_deleted_rows << "'#{row[primary_key]}'"
+            to_be_deleted_rows << "'#{row[audit_table_pk]}'"
           when "UPDATE"
             set_values = new_row.map do |column, value|
               "#{column} = '#{value}'"
@@ -100,14 +100,14 @@ module PgOnlineSchemaChange
             SQL
             to_be_replayed << sql
 
-            to_be_deleted_rows << "'#{row[primary_key]}'"
+            to_be_deleted_rows << "'#{row[audit_table_pk]}'"
           when "DELETE"
             sql = <<~SQL
               DELETE FROM #{shadow_table} WHERE #{primary_key}=\'#{row[primary_key]}\';
             SQL
             to_be_replayed << sql
 
-            to_be_deleted_rows << "'#{row[primary_key]}'"
+            to_be_deleted_rows << "'#{row[audit_table_pk]}'"
           end
         end
 
@@ -117,7 +117,7 @@ module PgOnlineSchemaChange
         return unless to_be_deleted_rows.count >= 1
 
         delete_query = <<~SQL
-          DELETE FROM #{audit_table} WHERE #{primary_key} IN (#{to_be_deleted_rows.join(",")})
+          DELETE FROM #{audit_table} WHERE #{audit_table_pk} IN (#{to_be_deleted_rows.join(",")})
         SQL
         Query.run(client.connection, delete_query, reuse_trasaction)
       end

--- a/spec/fixtures/bench.sql
+++ b/spec/fixtures/bench.sql
@@ -1,0 +1,12 @@
+\set aid random(1, 100000 * :scale)
+\set bid random(1, 1 * :scale)
+\set tid random(1, 10 * :scale)
+\set delta random(-5000, 5000)
+BEGIN;
+UPDATE pgbench_accounts SET abalance = abalance + :delta WHERE aid = :aid;
+UPDATE pgbench_accounts_validate SET abalance = abalance + :delta WHERE aid = :aid;
+SELECT abalance FROM pgbench_accounts WHERE aid = :aid;
+UPDATE pgbench_tellers SET tbalance = tbalance + :delta WHERE tid = :tid;
+UPDATE pgbench_branches SET bbalance = bbalance + :delta WHERE bid = :bid;
+INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES (:tid, :bid, :aid, :delta, CURRENT_TIMESTAMP);
+END;

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -13,11 +13,12 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
       client = PgOnlineSchemaChange::Client.new(client_options)
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
 
-      expect(client.connection).to receive(:async_exec).with("BEGIN;").exactly(5).times.and_call_original
+      expect(client.connection).to receive(:async_exec).with("BEGIN;").exactly(6).times.and_call_original
+      expect(client.connection).to receive(:async_exec).with(/convalidated AS constraint_validated/).and_call_original
       expect(client.connection).to receive(:async_exec).with("SET statement_timeout = 0;\nSET client_min_messages = warning;\nSET search_path TO #{client.schema};\n").and_call_original
       expect(client.connection).to receive(:async_exec).with(FUNC_FIX_SERIAL_SEQUENCE).and_call_original
       expect(client.connection).to receive(:async_exec).with(FUNC_CREATE_TABLE_ALL).and_call_original
-      expect(client.connection).to receive(:async_exec).with("COMMIT;").exactly(5).times.and_call_original
+      expect(client.connection).to receive(:async_exec).with("COMMIT;").exactly(6).times.and_call_original
       expect(client.connection).to receive(:async_exec).with("SHOW statement_timeout;").and_call_original
       expect(client.connection).to receive(:async_exec).with("SHOW client_min_messages;").and_call_original
 
@@ -866,7 +867,6 @@ RSpec.describe PgOnlineSchemaChange::Orchestrate do
     end
 
     it "closes transaction when it couldn't acquire lock" do
-      expect(PgOnlineSchemaChange::Query).to receive(:get_foreign_keys_to_refresh).with(client, client.table)
       expect(PgOnlineSchemaChange::Query).to receive(:run).with(
         client.connection,
         "SET statement_timeout = 0;",


### PR DESCRIPTION
This has few changes

- Once it replays items from the audit table, it deletes
those rows after. However, it was deleting rows by the PK
of the primary table and not the audit table, which created
a race condition on high volume tables.
- Moves up setting alter statement refresh commands in the Store
to avoid any risk of leaky transactions in the end

Tested this manually using pgbench and no longer seeing
any mis match between data post pg-osc run.

Will be bringing that integration test to CI (https://github.com/shayonj/pg-osc/issues/61), so we can run them
on every commit and catch regressions early

<img width="1643" alt="image" src="https://user-images.githubusercontent.com/1100970/155904382-715d8a30-f471-4c45-bae0-49c9628ef4eb.png">

fixes: https://github.com/shayonj/pg-osc/issues/58
Nice find @jfrost !