### PR TITLE
off-by-one: Don't skip PK sequence value by one

### DIFF
--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -338,7 +338,7 @@ module PgOnlineSchemaChange
         return "" if sequence_name.nil?
 
         <<~SQL
-          SELECT setval((select pg_get_serial_sequence(\'#{shadow_table}\', \'#{primary_key}\')), (SELECT max(#{primary_key}) FROM #{table})+1);
+          SELECT setval((select pg_get_serial_sequence(\'#{shadow_table}\', \'#{primary_key}\')), (SELECT max(#{primary_key}) FROM #{table}));
         SQL
       end
     end


### PR DESCRIPTION
`setval` updates the `currval` on the sequence. So, we don't need to do a `+1` on the `max. Doing so, would skip a sequence value. Added a breaking spec. 

ht/ https://github.com/shayonj/pg-osc/pull/73#discussion_r979254672