### PR TITLE
Supports tablenames containing uppercase letters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 version: '2'
 services:
   postgres:
-    image: postgres:9.6.2-alpine
+    image: postgres:12-alpine
     ports:
-      - "5432:5432"
+      - "6000:6000"
     environment:
       POSTGRES_USER: jamesbond
       POSTGRES_DB: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 version: '2'
 services:
   postgres:
-    image: postgres:12-alpine
+    image: postgres:9.6.2-alpine
     ports:
-      - "6000:6000"
+      - "5432:5432"
     environment:
       POSTGRES_USER: jamesbond
       POSTGRES_DB: postgres
-      POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,3 @@ services:
     environment:
       POSTGRES_USER: jamesbond
       POSTGRES_DB: postgres
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
     environment:
       POSTGRES_USER: jamesbond
       POSTGRES_DB: postgres
+

--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -4,7 +4,7 @@ require "pg"
 
 module PgOnlineSchemaChange
   class Client
-    attr_accessor :alter_statement, :schema, :dbname, :host, :username, :port, :password, :connection, :table, :drop,
+    attr_accessor :alter_statement, :schema, :dbname, :host, :username, :port, :password, :connection, :table, :table_name, :drop,
                   :kill_backends, :wait_time_for_lock, :copy_statement, :pull_batch_count, :delta_count
 
     def initialize(options)
@@ -33,6 +33,9 @@ module PgOnlineSchemaChange
       )
 
       @table = Query.table(@alter_statement)
+      @table_name = Query.table_name(@alter_statement, @table)
+      puts @table
+      puts @table_name
 
       PgOnlineSchemaChange.logger.debug("Connection established")
     end

--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -34,8 +34,6 @@ module PgOnlineSchemaChange
 
       @table = Query.table(@alter_statement)
       @table_name = Query.table_name(@alter_statement, @table)
-      puts @table
-      puts @table_name
 
       PgOnlineSchemaChange.logger.debug("Connection established")
     end

--- a/lib/pg_online_schema_change/helper.rb
+++ b/lib/pg_online_schema_change/helper.rb
@@ -6,7 +6,7 @@ module PgOnlineSchemaChange
       result = Store.get(:primary_key)
       return result if result
 
-      Store.set(:primary_key, Query.primary_key_for(client, client.table))
+      Store.set(:primary_key, Query.primary_key_for(client, client.table_name))
     end
 
     def logger

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -10,7 +10,6 @@ module PgOnlineSchemaChange
 
     class << self
       def setup!(options)
-        puts options
         client = Store.set(:client, Client.new(options))
 
         sql = <<~SQL

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -10,6 +10,7 @@ module PgOnlineSchemaChange
 
     class << self
       def setup!(options)
+        puts options
         client = Store.set(:client, Client.new(options))
 
         sql = <<~SQL
@@ -30,16 +31,16 @@ module PgOnlineSchemaChange
         # Set this early on to ensure their creation and cleanup (unexpected)
         # happens at all times. IOW, the calls from Store.get always return
         # the same value.
-        Store.set(:old_primary_table, "pgosc_op_table_#{client.table}")
-        Store.set(:audit_table, "pgosc_at_#{client.table}_#{pgosc_identifier}")
+        Store.set(:old_primary_table, "pgosc_op_table_#{client.table.downcase}")
+        Store.set(:audit_table, "pgosc_at_#{client.table.downcase}_#{pgosc_identifier}")
         Store.set(:operation_type_column, "operation_type_#{pgosc_identifier}")
         Store.set(:trigger_time_column, "trigger_time_#{pgosc_identifier}")
         Store.set(:audit_table_pk, "at_#{pgosc_identifier}_id")
         Store.set(:audit_table_pk_sequence, "#{audit_table}_#{audit_table_pk}_seq")
-        Store.set(:shadow_table, "pgosc_st_#{client.table}_#{pgosc_identifier}")
+        Store.set(:shadow_table, "pgosc_st_#{client.table.downcase}_#{pgosc_identifier}")
 
-        Store.set(:referential_foreign_key_statements, Query.referential_foreign_keys_to_refresh(client, client.table))
-        Store.set(:self_foreign_key_statements, Query.self_foreign_keys_to_refresh(client, client.table))
+        Store.set(:referential_foreign_key_statements, Query.referential_foreign_keys_to_refresh(client, client.table_name))
+        Store.set(:self_foreign_key_statements, Query.self_foreign_keys_to_refresh(client, client.table_name))
       end
 
       def run!(options)
@@ -98,7 +99,7 @@ module PgOnlineSchemaChange
         logger.info("Setting up audit table", { audit_table: audit_table })
 
         sql = <<~SQL
-          CREATE TABLE #{audit_table} (#{audit_table_pk} SERIAL PRIMARY KEY, #{operation_type_column} text, #{trigger_time_column} timestamp, LIKE #{client.table});
+          CREATE TABLE #{audit_table} (#{audit_table_pk} SERIAL PRIMARY KEY, #{operation_type_column} text, #{trigger_time_column} timestamp, LIKE #{client.table_name});
         SQL
 
         Query.run(client.connection, sql)
@@ -108,14 +109,14 @@ module PgOnlineSchemaChange
         # acquire access exclusive lock to ensure audit triggers
         # are setup fine. This also calls kill_backends (if opted in via flag)
         # so any competing backends will be killed to setup the trigger
-        opened = Query.open_lock_exclusive(client, client.table)
+        opened = Query.open_lock_exclusive(client, client.table_name)
 
         raise AccessExclusiveLockNotAcquired unless opened
 
         logger.info("Setting up triggers")
 
         sql = <<~SQL
-          DROP TRIGGER IF EXISTS primary_to_audit_table_trigger ON #{client.table};
+          DROP TRIGGER IF EXISTS primary_to_audit_table_trigger ON #{client.table_name};
 
           CREATE OR REPLACE FUNCTION primary_to_audit_table_trigger()
           RETURNS TRIGGER AS
@@ -135,7 +136,7 @@ module PgOnlineSchemaChange
           $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
           CREATE TRIGGER primary_to_audit_table_trigger
-          AFTER INSERT OR UPDATE OR DELETE ON #{client.table}
+          AFTER INSERT OR UPDATE OR DELETE ON #{client.table_name}
           FOR EACH ROW EXECUTE PROCEDURE primary_to_audit_table_trigger();
         SQL
 
@@ -156,16 +157,16 @@ module PgOnlineSchemaChange
         Query.run(client.connection, "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE", true)
         logger.info("Setting up shadow table", { shadow_table: shadow_table })
 
-        Query.run(client.connection, "SELECT create_table_all('#{client.table}', '#{shadow_table}');", true)
+        Query.run(client.connection, "SELECT create_table_all('#{client.table_name}', '#{shadow_table}');", true)
 
         # update serials
-        Query.run(client.connection, "SELECT fix_serial_sequence('#{client.table}', '#{shadow_table}');", true)
+        Query.run(client.connection, "SELECT fix_serial_sequence('#{client.table_name}', '#{shadow_table}');", true)
       end
 
       def disable_vacuum!
         # re-uses transaction with serializable
         # Disabling vacuum to avoid any issues during the process
-        result = Query.storage_parameters_for(client, client.table, true) || ""
+        result = Query.storage_parameters_for(client, client.table_name, true) || ""
         Store.set(:primary_table_storage_parameters, result)
 
         logger.debug("Disabling vacuum on shadow and audit table",
@@ -186,7 +187,7 @@ module PgOnlineSchemaChange
         # re-uses transaction with serializable
         statement = Query.alter_statement_for(client, shadow_table)
         logger.info("Running alter statement on shadow table",
-                    { shadow_table: shadow_table, parent_table: client.table })
+                    { shadow_table: shadow_table, parent_table: client.table_name })
         Query.run(client.connection, statement, true)
 
         Store.set(:dropped_columns_list, Query.dropped_columns(client))
@@ -198,10 +199,10 @@ module PgOnlineSchemaChange
         # Begin the process to copy data into copy table
         # depending on the size of the table, this can be a time
         # taking operation.
-        logger.info("Clearing contents of audit table before copy..", { shadow_table: shadow_table, parent_table: client.table })
+        logger.info("Clearing contents of audit table before copy..", { shadow_table: shadow_table, parent_table: client.table_name })
         Query.run(client.connection, "DELETE FROM #{audit_table}", true)
 
-        logger.info("Copying contents..", { shadow_table: shadow_table, parent_table: client.table })
+        logger.info("Copying contents..", { shadow_table: shadow_table, parent_table: client.table_name })
         if client.copy_statement
           query = format(client.copy_statement, shadow_table: shadow_table)
           return Query.run(client.connection, query, true)
@@ -224,12 +225,12 @@ module PgOnlineSchemaChange
       def swap!
         logger.info("Performing swap!")
 
-        storage_params_reset = primary_table_storage_parameters.empty? ? "" : "ALTER TABLE #{client.table} SET (#{primary_table_storage_parameters});"
+        storage_params_reset = primary_table_storage_parameters.empty? ? "" : "ALTER TABLE #{client.table_name} SET (#{primary_table_storage_parameters});"
 
         # From here on, all statements are carried out in a single
         # transaction with access exclusive lock
 
-        opened = Query.open_lock_exclusive(client, client.table)
+        opened = Query.open_lock_exclusive(client, client.table_name)
 
         raise AccessExclusiveLockNotAcquired unless opened
 
@@ -238,16 +239,16 @@ module PgOnlineSchemaChange
         rows = Replay.rows_to_play(opened)
         Replay.play!(rows, opened)
 
-        query_for_primary_key_refresh = Query.query_for_primary_key_refresh(shadow_table, primary_key, client.table, opened)
+        query_for_primary_key_refresh = Query.query_for_primary_key_refresh(shadow_table, primary_key, client.table_name, opened)
 
         sql = <<~SQL
           #{query_for_primary_key_refresh};
-          ALTER TABLE #{client.table} RENAME to #{old_primary_table};
-          ALTER TABLE #{shadow_table} RENAME to #{client.table};
+          ALTER TABLE #{client.table_name} RENAME to #{old_primary_table};
+          ALTER TABLE #{shadow_table} RENAME to #{client.table_name};
           #{referential_foreign_key_statements}
           #{self_foreign_key_statements}
           #{storage_params_reset}
-          DROP TRIGGER IF EXISTS primary_to_audit_table_trigger ON #{client.table};
+          DROP TRIGGER IF EXISTS primary_to_audit_table_trigger ON #{client.table_name};
         SQL
 
         Query.run(client.connection, sql, opened)
@@ -259,13 +260,13 @@ module PgOnlineSchemaChange
       def run_analyze!
         logger.info("Performing ANALYZE!")
 
-        Query.run(client.connection, "ANALYZE VERBOSE #{client.table};")
+        Query.run(client.connection, "ANALYZE VERBOSE #{client.table_name};")
       end
 
       def validate_constraints!
         logger.info("Validating constraints!")
 
-        validate_statements = Query.get_foreign_keys_to_validate(client, client.table)
+        validate_statements = Query.get_foreign_keys_to_validate(client, client.table_name)
 
         Query.run(client.connection, validate_statements)
       end
@@ -276,7 +277,7 @@ module PgOnlineSchemaChange
         shadow_table_drop = shadow_table ? "DROP TABLE IF EXISTS #{shadow_table}" : ""
 
         sql = <<~SQL
-          DROP TRIGGER IF EXISTS primary_to_audit_table_trigger ON #{client.table};
+          DROP TRIGGER IF EXISTS primary_to_audit_table_trigger ON #{client.table_name};
           #{audit_table_drop};
           #{shadow_table_drop};
           #{primary_drop}

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe PgOnlineSchemaChange::Client do
     expect(client.port).to eq(5432)
     expect(client.connection).to be_instance_of(PG::Connection)
     expect(client.table).to eq("books")
+    expect(client.table_name).to eq("books")
     expect(client.drop).to eq(false)
     expect(client.copy_statement).to eq(nil)
     expect(client.delta_count).to eq(20)

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -79,9 +79,26 @@ RSpec.describe PgOnlineSchemaChange::Query do
       expect(described_class.table(query)).to eq("books")
     end
 
+    it "returns the table name for uppercase tables" do
+      query = "ALTER TABLE \"Books\" ADD COLUMN \"purchased\" BOOLEAN DEFAULT FALSE;"
+      expect(described_class.table(query)).to eq("Books")
+    end
+
     it "returns the table name for rename statements" do
       query = "ALTER TABLE books RENAME COLUMN \"email\" to \"new_email\";"
       expect(described_class.table(query)).to eq("books")
+    end
+  end
+
+  describe ".table_name" do
+    it "returns the table name for lowercase tables" do
+      query = "ALTER TABLE books ADD COLUMN \"purchased\" BOOLEAN DEFAULT FALSE;"
+      expect(described_class.table(query)).to eq("books")
+    end
+
+    it "returns quoted table name for uppercase tables" do
+      query = "ALTER TABLE \"Books\" ADD COLUMN \"purchased\" BOOLEAN DEFAULT FALSE;"
+      expect(described_class.table_name(query, "Books")).to eq("\"Books\"")
     end
   end
 

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -480,7 +480,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
           pg_attribute.attname as column_name
         FROM pg_index, pg_class, pg_attribute, pg_namespace
         WHERE
-          pg_class.oid = \'#{client.table}\'::regclass AND
+          pg_class.oid = \'#{client.table_name}\'::regclass AND
           indrelid = pg_class.oid AND
           nspname = \'#{client.schema}\' AND
           pg_class.relnamespace = pg_namespace.oid AND
@@ -493,7 +493,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
       expect(client.connection).to receive(:async_exec).with(query).and_call_original
       expect(client.connection).to receive(:async_exec).with("COMMIT;").and_call_original
 
-      result = described_class.primary_key_for(client, client.table)
+      result = described_class.primary_key_for(client, client.table_name)
       expect(result).to eq("user_id")
     end
   end
@@ -707,7 +707,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
       pid = fork do
         new_client = PgOnlineSchemaChange::Client.new(client_options)
         setup_tables(new_client)
-        new_client.connection.async_exec("SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table} IN ACCESS EXCLUSIVE MODE;")
+        new_client.connection.async_exec("SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;")
 
         sleep 50
       rescue StandardError => e
@@ -740,7 +740,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
       pid = fork do
         new_client = PgOnlineSchemaChange::Client.new(client_options)
         setup_tables(new_client)
-        new_client.connection.async_exec("SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table} IN ACCESS EXCLUSIVE MODE;")
+        new_client.connection.async_exec("SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;")
 
         sleep 50
       rescue StandardError
@@ -769,7 +769,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
       pid = fork do
         new_client = PgOnlineSchemaChange::Client.new(client_options)
         setup_tables(new_client)
-        new_client.connection.async_exec("SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table} IN ACCESS EXCLUSIVE MODE;")
+        new_client.connection.async_exec("SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;")
 
         sleep 10
       rescue StandardError
@@ -822,7 +822,7 @@ RSpec.describe PgOnlineSchemaChange::Query do
       pid = fork do
         new_client = PgOnlineSchemaChange::Client.new(client_options)
         setup_tables(new_client)
-        new_client.connection.async_exec("SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table} IN ACCESS EXCLUSIVE MODE;")
+        new_client.connection.async_exec("SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;")
 
         sleep 5
       rescue StandardError


### PR DESCRIPTION
Postgres has a notorious issue of requiring double quotes in relation identifiers when uppercase letters are contained. In other words, if a table was created with `CREATE TABLE "CamelCaseTable" blah`,  referring to the table using `CamelCaseTable` in queries will trigger a relation not found error. One has to use `"CamelCaseTable"`. It seems that upstream `pg_query` does not handle this as well.

Luckily Ruby is interpreted so I'll be able to modify locally to make the tool work for my use case (thanks!), but I thought a PR might be nice.

Putting it up as draft right now as I have not added test cases.