### PR TITLE
Re-enable autovacuum

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -247,16 +247,6 @@ module PgOnlineSchemaChange
 
       def swap!
         logger.info("Performing swap!")
-        puts primary_table_storage_parameters
-        storage_params_reset = "ALTER TABLE #{client.table_name} RESET (autovacuum_enabled, toast.autovacuum_enabled);" +
-          (
-            if primary_table_storage_parameters.empty?
-              ""
-            else
-              "ALTER TABLE #{client.table_name} SET (#{primary_table_storage_parameters});"
-            end
-          )
-
         # From here on, all statements are carried out in a single
         # transaction with access exclusive lock
 
@@ -329,6 +319,17 @@ module PgOnlineSchemaChange
 
       def pgosc_identifier
         @pgosc_identifier ||= SecureRandom.hex(3)
+      end
+
+      def storage_params_reset
+        "ALTER TABLE #{client.table_name} RESET (autovacuum_enabled, toast.autovacuum_enabled);" +
+          (
+            if primary_table_storage_parameters.empty?
+              ""
+            else
+              "ALTER TABLE #{client.table_name} SET (#{primary_table_storage_parameters});"
+            end
+          )
       end
     end
   end

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -253,7 +253,7 @@ module PgOnlineSchemaChange
             if primary_table_storage_parameters.empty?
               "ALTER TABLE #{shadow_table} RESET (autovacuum_enabled, toast.autovacuum_enabled);"
             else
-              "ALTER TABLE #{shadow} SET (#{primary_table_storage_parameters});"
+              "ALTER TABLE #{shadow_table} SET (#{primary_table_storage_parameters});"
             end
           )
 

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -251,9 +251,9 @@ module PgOnlineSchemaChange
         storage_params_reset =
           (
             if primary_table_storage_parameters.empty?
-              ""
+              "ALTER TABLE #{shadow_table} RESET (autovacuum_enabled, toast.autovacuum_enabled);"
             else
-              "ALTER TABLE #{client.table_name} SET (#{primary_table_storage_parameters});"
+              "ALTER TABLE #{shadow} SET (#{primary_table_storage_parameters});"
             end
           )
 

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -248,12 +248,12 @@ module PgOnlineSchemaChange
       def swap!
         logger.info("Performing swap!")
         puts primary_table_storage_parameters
-        storage_params_reset =
+        storage_params_reset = "ALTER TABLE #{client.table_name} RESET (autovacuum_enabled, toast.autovacuum_enabled);" +
           (
             if primary_table_storage_parameters.empty?
-              "ALTER TABLE #{shadow_table} RESET (autovacuum_enabled, toast.autovacuum_enabled);"
+              ""
             else
-              "ALTER TABLE #{shadow_table} SET (#{primary_table_storage_parameters});"
+              "ALTER TABLE #{client.table_name} SET (#{primary_table_storage_parameters});"
             end
           )
 

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -1098,6 +1098,12 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
       )
     end
 
+    it "sucessfully resets the autovacuum" do
+      described_class.swap!
+
+      expect(PgOnlineSchemaChange::Query.storage_parameters_for(client, client.table_name, true)).to eq("autovacuum_enabled=true,autovacuum_vacuum_scale_factor=0,autovacuum_vacuum_threshold=20000")
+    end
+
     it "transfers the foreign keys from parent table" do
       described_class.swap!
 


### PR DESCRIPTION
Also fix the table name for this part of the process.

This is a quick fix for tables with no storage parameters but does not fix the issue if autovacuum is enabled but other storage parameters are indeed set.

Fixes #82 