### PR TITLE
Support for views

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ docker run --network host -it --rm shayonj/pg-osc:latest \
   - Can be fixed in future releases. Feel free to open a feature req.
 - Foreign keys are dropped & re-added to referencing tables with a `NOT VALID`. A follow on `VALIDATE CONSTRAINT` is run.
   - Ensures that integrity is maintained and re-introducing FKs doesn't acquire additional locks, hence the `NOT VALID`.
-- After the migration is complete any `views` will continue to reference the old shadow table. Follow: https://github.com/shayonj/pg-osc/issues/81
 
 ## How does it work
 

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -299,8 +299,6 @@ module PgOnlineSchemaChange
       end
 
       def replace_views!
-        # Grab the views matching the pgosc op table name. So there are less chances of partial
-        # table name matches from within Query.view_definitions_for
         view_definitions = Query.view_definitions_for(client, old_primary_table)
         view_definitions.each do |definition|
           definition.each do |view_name, view_definition|

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -303,14 +303,20 @@ module PgOnlineSchemaChange
 
       def view_definitions_for(client, table)
         query = <<~SQL
-          select *
-          from INFORMATION_SCHEMA.VIEWS
-          where VIEW_DEFINITION like '%#{table}%'
+          SELECT DISTINCT dependent_view.relname as view_name, pg_get_viewdef(dependent_view.relname::regclass) as view_definition
+          FROM pg_depend
+          JOIN pg_rewrite ON pg_depend.objid = pg_rewrite.oid
+          JOIN pg_class as dependent_view ON pg_rewrite.ev_class = dependent_view.oid
+          JOIN pg_class as source_table ON pg_depend.refobjid = source_table.oid
+          JOIN pg_namespace source_ns ON source_ns.oid = source_table.relnamespace
+          WHERE
+          source_ns.nspname = '#{client.schema}'
+          AND source_table.relname = '#{table}'
         SQL
 
         definitions = []
         run(client.connection, query) do |result|
-          definitions = result.map { |row| {row["table_name"] => row["view_definition"].strip} }
+          definitions = result.map { |row| {row["view_name"] => row["view_definition"].strip} }
         end
 
         definitions

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -301,6 +301,21 @@ module PgOnlineSchemaChange
         columns.first
       end
 
+      def view_definitions_for(client, table)
+        query = <<~SQL
+          select *
+          from INFORMATION_SCHEMA.VIEWS
+          where VIEW_DEFINITION like '%#{table}%'
+        SQL
+
+        definitions = []
+        run(client.connection, query) do |result|
+          definitions = result.map { |row| {row["table_name"] => row["view_definition"].strip} }
+        end
+
+        definitions
+      end
+
       # This function acquires the lock and keeps the transaction
       # open. If a lock is acquired, its upon the caller
       # to call COMMIT to end the transaction. If a lock

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -1313,9 +1313,8 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
 
       described_class.swap!
 
-      # Views for both parent and op table return the same value
       expect(PgOnlineSchemaChange::Query.view_definitions_for(client, described_class.old_primary_table)).to eq(expected_views_result_op_table)
-      expect(PgOnlineSchemaChange::Query.view_definitions_for(client, client.table)).to eq(expected_views_result_op_table)
+      expect(PgOnlineSchemaChange::Query.view_definitions_for(client, client.table)).to eq([])
 
       # Add an entry to check re-creation of view was successful with new data
       query = <<~SQL

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -1270,6 +1270,73 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
     end
   end
 
+  describe ".replace_views!" do
+    let(:client) { PgOnlineSchemaChange::Client.new(client_options) }
+
+    before do
+      allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
+      setup_tables(client)
+      described_class.setup!(client_options)
+
+      ingest_dummy_data_into_dummy_table(client)
+
+      described_class.setup_audit_table!
+      described_class.setup_trigger!
+      described_class.setup_shadow_table!
+      described_class.disable_vacuum!
+      described_class.run_alter_statement!
+      described_class.copy_data!
+      described_class.dropped_columns_list
+      PgOnlineSchemaChange::Replay.play!([])
+    end
+
+    it "succesfully recreates the view" do
+      expected_views_result = [
+        {
+          "books_view" =>"SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM books\n  WHERE (books.seller_id = 1);",
+        }
+      ]
+      expected_views_result_op_table = [
+        {
+          "books_view" =>"SELECT pgosc_op_table_books.user_id,\n    pgosc_op_table_books.username,\n    pgosc_op_table_books.seller_id,\n    pgosc_op_table_books.password,\n    pgosc_op_table_books.email,\n    pgosc_op_table_books.\"createdOn\",\n    pgosc_op_table_books.last_login\n   FROM pgosc_op_table_books\n  WHERE (pgosc_op_table_books.seller_id = 1);",
+        }
+      ]
+
+      rows = []
+      PgOnlineSchemaChange::Query.run(client.connection, "select count(*) from  books_view;") do |result|
+        rows = result.map { |row| row }
+      end
+      expect(rows.first["count"]).to eq("3")
+
+      expect(PgOnlineSchemaChange::Query.view_definitions_for(client, described_class.old_primary_table)).to eq([])
+      expect(PgOnlineSchemaChange::Query.view_definitions_for(client, client.table)).to eq(expected_views_result)
+
+      described_class.swap!
+
+      # Views for both parent and op table return the same value
+      expect(PgOnlineSchemaChange::Query.view_definitions_for(client, described_class.old_primary_table)).to eq(expected_views_result_op_table)
+      expect(PgOnlineSchemaChange::Query.view_definitions_for(client, client.table)).to eq(expected_views_result_op_table)
+
+      # Add an entry to check re-creation of view was successful with new data
+      query = <<~SQL
+        INSERT INTO "books"("user_id", "seller_id", "username", "password", "email", "createdOn", "last_login")
+        VALUES(4, 1, 'jamesbond', '007', 'james@bond.com', clock_timestamp(), clock_timestamp()) RETURNING "user_id", "username", "password", "email", "createdOn", "last_login";
+       SQL
+      PgOnlineSchemaChange::Query.run(client.connection, query)
+
+      described_class.replace_views!
+
+      expect(PgOnlineSchemaChange::Query.view_definitions_for(client, described_class.old_primary_table)).to eq([])
+      expect(PgOnlineSchemaChange::Query.view_definitions_for(client, client.table)).to eq(expected_views_result)
+
+      rows = []
+      PgOnlineSchemaChange::Query.run(client.connection, "select count(*) from books_view;") do |result|
+        rows = result.map { |row| row }
+      end
+      expect(rows.first["count"]).to eq("4")
+    end
+  end
+
   describe ".drop_and_cleanup!" do
     let(:client) { PgOnlineSchemaChange::Client.new(client_options) }
 
@@ -1284,10 +1351,11 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
       described_class.setup_trigger!
       described_class.setup_shadow_table!
       described_class.disable_vacuum!
-      described_class.copy_data!
       described_class.run_alter_statement!
+      described_class.copy_data!
       PgOnlineSchemaChange::Replay.play!([])
       described_class.swap!
+      described_class.replace_views!
     end
 
     it "sucessfully drops audit table" do

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -678,6 +678,20 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
     end
   end
 
+  describe ".view_definitions_for" do
+    it "returns all the definitions successfully" do
+      client = PgOnlineSchemaChange::Client.new(client_options)
+      setup_tables(client)
+      ingest_dummy_data_into_dummy_table(client)
+      result = described_class.view_definitions_for(client, "books")
+      expect(result).to eq([
+        {
+          "books_view" =>"SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM books\n  WHERE (books.seller_id = 1);",
+        }
+      ])
+    end
+  end
+
   describe ".copy_data_statement" do
     let(:client) do
       client = PgOnlineSchemaChange::Client.new(client_options)

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -108,6 +108,11 @@ module DatabaseHelpers
         (1, 'jamesbond2', '007', 'james1@bond.com', clock_timestamp(), clock_timestamp()),
         (1, 'jamesbond3', '008', 'james2@bond.com', clock_timestamp(), clock_timestamp()),
         (1, 'jamesbond4', '009', 'james3@bond.com', clock_timestamp(), clock_timestamp());
+
+      CREATE OR REPLACE VIEW Books_view AS
+        SELECT *
+        FROM books
+        WHERE seller_id = 1;
     SQL
     PgOnlineSchemaChange::Query.run(client.connection, query)
   end


### PR DESCRIPTION
pg-osc will now re-create any views after the table name swap. Because pg-osc uses shadow tables, after the name swap happens, views can continue to refer the old table name. This isn't ideal.

Instead, we now perform a `CREATE OR REPLACE VIEW`... after the swap is performed. We do it after swap to ensure any view creation doesn't keep the exclusive lock held for a longer duration.

Closes: https://github.com/shayonj/pg-osc/issues/81