### PR TITLE
Create shadow and audit with auatovacuum default

### DIFF
--- a/lib/pg_online_schema_change/functions.rb
+++ b/lib/pg_online_schema_change/functions.rb
@@ -45,7 +45,7 @@ FUNC_CREATE_TABLE_ALL = <<~SQL
         rec record;
     begin
     EXECUTE format(
-          'CREATE TABLE %s (LIKE %s including all)',
+          'CREATE TABLE %s (LIKE %s including all) WITH (autovacuum_enabled = false)',
           newsource_table, source_table);
     END
   $$;

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -81,7 +81,6 @@ module PgOnlineSchemaChange
         connection.block
         logger.info("Exception raised, rolling back query", { rollback: true, query: query })
         connection.async_exec("ROLLBACK;")
-        connection.async_exec("COMMIT;")
         raise
       else
         connection.async_exec("COMMIT;") unless reuse_trasaction

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       expect(client.connection).to receive(:async_exec).with(
         /FROM   	pg_constraint/,
       ).and_call_original
-      expect(client.connection).to receive(:async_exec).with("COMMIT;").twice.and_call_original
+      expect(client.connection).to receive(:async_exec).with("COMMIT;").once.and_call_original
 
       allow(client.connection).to receive(:async_exec).with(alter_query).and_raise(
         PG::DependentObjectsStillExist,
@@ -818,7 +818,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
   end
 
   describe ".open_lock_exclusive with forked process and kills backend" do
-    it "cannot acquire lock at first, kills backend (forked process), sucesfully acquires lock and returns true" do
+    it "cannot acquire lock at first, kills backend (forked process), sucessfully acquires lock and returns true" do
       pid =
         fork do
           new_client = PgOnlineSchemaChange::Client.new(client_options)

--- a/spec/lib/replay_spec.rb
+++ b/spec/lib/replay_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe(PgOnlineSchemaChange::Replay) do
         PgOnlineSchemaChange::Orchestrate.setup_audit_table!
         PgOnlineSchemaChange::Orchestrate.setup_trigger!
         PgOnlineSchemaChange::Orchestrate.setup_shadow_table!
-        PgOnlineSchemaChange::Orchestrate.disable_vacuum!
         PgOnlineSchemaChange::Orchestrate.run_alter_statement!
         PgOnlineSchemaChange::Orchestrate.copy_data!
       end
@@ -230,7 +229,6 @@ RSpec.describe(PgOnlineSchemaChange::Replay) do
         PgOnlineSchemaChange::Orchestrate.setup_audit_table!
         PgOnlineSchemaChange::Orchestrate.setup_trigger!
         PgOnlineSchemaChange::Orchestrate.setup_shadow_table!
-        PgOnlineSchemaChange::Orchestrate.disable_vacuum!
         PgOnlineSchemaChange::Orchestrate.run_alter_statement!
         PgOnlineSchemaChange::Orchestrate.copy_data!
       end
@@ -401,7 +399,6 @@ RSpec.describe(PgOnlineSchemaChange::Replay) do
         PgOnlineSchemaChange::Orchestrate.setup_audit_table!
         PgOnlineSchemaChange::Orchestrate.setup_trigger!
         PgOnlineSchemaChange::Orchestrate.setup_shadow_table!
-        PgOnlineSchemaChange::Orchestrate.disable_vacuum!
         PgOnlineSchemaChange::Orchestrate.run_alter_statement!
         PgOnlineSchemaChange::Orchestrate.copy_data!
       end


### PR DESCRIPTION
Calling an `ALTER` with a transaction open during serializable while we copy data onto the audit table could potentially lead to lock queues. This avoids doing so by removing the `disable_vaccum` function and taking advantage of `WITH` directive when setting up the shadow and audit table in the first place. Thus avoiding the need to perform an `ALTER` on audit table or shadow table and avoid locking. 

After some good findings from https://github.com/shayonj/pg-osc/issues/94 
h/t @yash-toddleapp