### PR TITLE
Adding support for showing the gem version with -v or --version.

### DIFF
--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -105,6 +105,7 @@ module PgOnlineSchemaChange
       PgOnlineSchemaChange::Orchestrate.run!(client_options)
     end
 
+    map %w[--version -v] => :version
     desc "--version, -v", "print the version"
 
     def version

--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -105,7 +105,7 @@ module PgOnlineSchemaChange
       PgOnlineSchemaChange::Orchestrate.run!(client_options)
     end
 
-    map %w[--version -v] => :version
+    map ['--version', '-v'] => :version
     desc "--version, -v", "print the version"
 
     def version


### PR DESCRIPTION
Currently the `-v` and `--version` options don't actually show the version. Here's what you get:

```
% pg-online-schema-change --version
No value provided for required options '--alter-statement', '--dbname', '--host', '--username'
```

This PR maps the `-v` and `--version` options to the correct method:

```
% pg-online-schema-change --version
0.9.2
```