### PR TITLE
INSERT's are failing for long table names 115

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -35,7 +35,6 @@ module PgOnlineSchemaChange
         Store.set(:operation_type_column, "operation_type_#{pgosc_identifier}")
         Store.set(:trigger_time_column, "trigger_time_#{pgosc_identifier}")
         Store.set(:audit_table_pk, "at_#{pgosc_identifier}_id")
-        Store.set(:audit_table_pk_sequence, "#{audit_table}_#{audit_table_pk}_seq")
         Store.set(:shadow_table, "pgosc_st_#{client.table.downcase}_#{pgosc_identifier}")
         Store.set(:primary_table_storage_parameters, Query.storage_parameters_for(client, client.table_name, true) || "")
 
@@ -109,6 +108,8 @@ module PgOnlineSchemaChange
         SQL
 
         Query.run(client.connection, sql)
+
+        Store.set(:audit_table_pk_sequence, Query.get_sequence_name(client, audit_table, audit_table_pk))
       end
 
       def setup_trigger!

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -134,6 +134,18 @@ module PgOnlineSchemaChange
         indexes
       end
 
+      # fetches the sequence name of a table and column combination
+      def get_sequence_name(client, table, column)
+        query = <<~SQL
+          SELECT pg_get_serial_sequence('#{table}', '#{column}');
+        SQL
+
+        run(client.connection, query) { |result| result.map { |row|
+          row["pg_get_serial_sequence"]
+        }
+        }.first
+      end
+
       def get_triggers_for(client, table)
         query = <<~SQL
           SELECT pg_get_triggerdef(oid) as tdef FROM pg_trigger

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -321,6 +321,14 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
           "constraint_validated" => "t",
           "definition" => "FOREIGN KEY (book_id) REFERENCES books(user_id)",
         },
+        {
+          "table_on" => "this_is_a_table_with_a_very_long_name",
+          "table_from" => "-",
+          "constraint_type" => "p",
+          "constraint_name" => "this_is_a_table_with_a_very_long_name_pkey",
+          "constraint_validated" => "t",
+          "definition" => "PRIMARY KEY (id)",
+        },
       ]
 
       expect(described_class.get_all_constraints_for(client)).to eq(result)

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -80,6 +80,11 @@ module DatabaseHelpers
         "createdOn" TIMESTAMP NOT NULL,
         last_login TIMESTAMP
       );
+      
+      CREATE TABLE IF NOT EXISTS #{schema}.this_is_a_table_with_a_very_long_name (
+        id serial PRIMARY KEY,
+        "createdOn" TIMESTAMP NOT NULL
+      );
 
       ALTER ROLE jamesbond SET statement_timeout = '60s';
       ALTER ROLE jamesbond SET lock_timeout = '60s';


### PR DESCRIPTION
#### Ticket
https://github.com/shayonj/pg-osc/issues/115

#### Idea
Use postgres `pg_get_serial_sequence` function to fetch the real sequence name.

#### Changes
Please see individual commits for the approach.

#### Example
##### Before: Sequence names are different

![Selection_883](https://github.com/shayonj/pg-osc/assets/4171011/31742b01-c082-408d-aa53-1551e339491b)

##### After: Sequence name match

![Selection_886](https://github.com/shayonj/pg-osc/assets/4171011/a380f47d-1641-474a-889c-81a2607d95e3)

