### PR TITLE
Get view definition of a view from dedicated schema

### DIFF
--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -314,7 +314,7 @@ module PgOnlineSchemaChange
 
       def view_definitions_for(client, table)
         query = <<~SQL
-          SELECT DISTINCT dependent_view.relname as view_name, pg_get_viewdef(dependent_view.relname::regclass) as view_definition
+          SELECT DISTINCT dependent_view.relname as view_name, pg_get_viewdef(format('%I.%I', '#{client.schema}', dependent_view.relname)::regclass) as view_definition
           FROM pg_depend
           JOIN pg_rewrite ON pg_depend.objid = pg_rewrite.oid
           JOIN pg_class as dependent_view ON pg_rewrite.ev_class = dependent_view.oid

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -691,10 +691,11 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       client = PgOnlineSchemaChange::Client.new(client_options)
       setup_tables(client)
       ingest_dummy_data_into_dummy_table(client)
+      described_class.run(client.connection, "reset search_path")
       result = described_class.view_definitions_for(client, "books")
       expect(result).to eq([
         {
-          "books_view" =>"SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM books\n  WHERE (books.seller_id = 1);",
+          "books_view" =>"SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM test_schema.books\n  WHERE (books.seller_id = 1);",
         }
       ])
     end


### PR DESCRIPTION
The search_path can get lost or not set when looking for the view definition via `pg_get_viewdef`. Hence we now pass in the schema in addition to the view name for `Query.view_definitions_for`

fixes: https://github.com/shayonj/pg-osc/issues/112