### PR TITLE
Validate one constraint at a time

### DIFF
--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -140,10 +140,9 @@ module PgOnlineSchemaChange
           SELECT pg_get_serial_sequence('#{table}', '#{column}');
         SQL
 
-        run(client.connection, query) { |result| result.map { |row|
-          row["pg_get_serial_sequence"]
-        }
-        }.first
+        run(client.connection, query) do |result|
+          result.map { |row| row["pg_get_serial_sequence"] }
+        end.first
       end
 
       def get_triggers_for(client, table)
@@ -238,11 +237,9 @@ module PgOnlineSchemaChange
         self_foreign_keys =
           constraints.select { |row| row["table_on"] == table && row["constraint_type"] == "f" }
 
-        [referential_foreign_keys, self_foreign_keys].flatten
-          .map do |row|
-            "ALTER TABLE #{row["table_on"]} VALIDATE CONSTRAINT #{row["constraint_name"]};"
-          end
-          .join
+        [referential_foreign_keys, self_foreign_keys].flatten.map do |row|
+          "ALTER TABLE #{row["table_on"]} VALIDATE CONSTRAINT #{row["constraint_name"]};"
+        end
       end
 
       def dropped_columns(client)
@@ -327,7 +324,7 @@ module PgOnlineSchemaChange
 
         definitions = []
         run(client.connection, query) do |result|
-          definitions = result.map { |row| {row["view_name"] => row["view_definition"].strip} }
+          definitions = result.map { |row| { row["view_name"] => row["view_definition"].strip } }
         end
 
         definitions

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -457,9 +457,13 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
     before { setup_tables(client) }
 
     it "returns drop and add statements" do
-      result =
-        "ALTER TABLE book_audits VALIDATE CONSTRAINT book_audits_book_id_fkey;ALTER TABLE chapters VALIDATE CONSTRAINT chapters_book_id_fkey;ALTER TABLE books VALIDATE CONSTRAINT books_seller_id_fkey;"
-      expect(described_class.get_foreign_keys_to_validate(client, "books")).to eq(result)
+      expect(described_class.get_foreign_keys_to_validate(client, "books")).to eq(
+        [
+          "ALTER TABLE book_audits VALIDATE CONSTRAINT book_audits_book_id_fkey;",
+          "ALTER TABLE chapters VALIDATE CONSTRAINT chapters_book_id_fkey;",
+          "ALTER TABLE books VALIDATE CONSTRAINT books_seller_id_fkey;",
+        ],
+      )
     end
   end
 
@@ -693,11 +697,14 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       ingest_dummy_data_into_dummy_table(client)
       described_class.run(client.connection, "reset search_path")
       result = described_class.view_definitions_for(client, "books")
-      expect(result).to eq([
-        {
-          "books_view" =>"SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM test_schema.books\n  WHERE (books.seller_id = 1);",
-        }
-      ])
+      expect(result).to eq(
+        [
+          {
+            "books_view" =>
+              "SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM test_schema.books\n  WHERE (books.seller_id = 1);",
+          },
+        ],
+      )
     end
   end
 


### PR DESCRIPTION
Just an optimization change to ensure a single transaction opened for too long when dealing with large tables

Related: https://github.com/shayonj/pg-osc/issues/119