### PR TITLE
Introduce --skip-foreign-key-validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ pg-online-schema-change (`pg-osc`) is a tool for making schema changes (any `ALT
 
 `pg-osc` is inspired by the design and workings of tools like `pg_repack` and `pt-online-schema-change` (MySQL). Read more below on [how does it work](#how-does-it-work), [prominent features](#prominent-features), the [caveats](#caveats) and [examples](#examples)
 
-⚠️ Proceed with caution when using this on production like workloads. Best to try on similar setup or staging like environment first. Read on below for some examples and caveats.
-
 ## Table of Contents
 
 - [Installation](#installation)
@@ -70,28 +68,29 @@ https://hub.docker.com/r/shayonj/pg-osc
 pg-online-schema-change help perform
 
 Usage:
-  pg-online-schema-change perform -a, --alter-statement=ALTER_STATEMENT -d, --dbname=DBNAME -h, --host=HOST -p, --port=N -s, --schema=SCHEMA -u, --username=USERNAME -w, --password=PASSWORD
+  pg-online-schema-change perform -a, --alter-statement=ALTER_STATEMENT -d, --dbname=DBNAME -h, --host=HOST -p, --port=N -s, --schema=SCHEMA -u, --username=USERNAME
 
 Options:
-  -a, --alter-statement=ALTER_STATEMENT        # The ALTER statement to perform the schema change
-  -s, --schema=SCHEMA                          # The schema in which the table is
-                                               # Default: public
-  -d, --dbname=DBNAME                          # Name of the database
-  -h, --host=HOST                              # Server host where the Database is located
-  -u, --username=USERNAME                      # Username for the Database
-  -p, --port=N                                 # Port for the Database
-                                               # Default: 5432
-  -w, --password=PASSWORD                      # DEPRECATED: Password for the Database. Please pass PGPASSWORD environment variable instead.
-  -v, [--verbose], [--no-verbose]              # Emit logs in debug mode
-  -f, [--drop], [--no-drop]                    # Drop the original table in the end after the swap
-  -k, [--kill-backends], [--no-kill-backends]  # Kill other competing queries/backends when trying to acquire lock for the shadow table creation and swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times.
-  -w, [--wait-time-for-lock=N]                 # Time to wait before killing backends to acquire lock and/or retrying upto 3 times. It will kill backends if --kill-backends is true, otherwise try upto 3 times and exit if it cannot acquire a lock.
-                                               # Default: 10
-  -c, [--copy-statement=COPY_STATEMENT]        # Takes a .sql file location where you can provide a custom query to be played (ex: backfills) when pgosc copies data from the primary to the shadow table. More examples in README.
-  -b, [--pull-batch-count=N]                   # Number of rows to be replayed on each iteration after copy. This can be tuned for faster catch up and swap. Best used with delta-count.
-                                               # Default: 1000
-  -e, [--delta-count=N]                        # Indicates how many rows should be remaining before a swap should be performed. This can be tuned for faster catch up and swap, especially on highly volume tables. Best used with pull-batch-count.
-                                               # Default: 20
+  -a, --alter-statement=ALTER_STATEMENT                                    # The ALTER statement to perform the schema change
+  -s, --schema=SCHEMA                                                      # The schema in which the table is
+                                                                           # Default: public
+  -d, --dbname=DBNAME                                                      # Name of the database
+  -h, --host=HOST                                                          # Server host where the Database is located
+  -u, --username=USERNAME                                                  # Username for the Database
+  -p, --port=N                                                             # Port for the Database
+                                                                           # Default: 5432
+  -w, [--password=PASSWORD]                                                # DEPRECATED: Password for the Database. Please pass PGPASSWORD environment variable instead.
+  -v, [--verbose], [--no-verbose]                                          # Emit logs in debug mode
+  -f, [--drop], [--no-drop]                                                # Drop the original table in the end after the swap
+  -k, [--kill-backends], [--no-kill-backends]                              # Kill other competing queries/backends when trying to acquire lock for the shadow table creation and swap. It will wait for --wait-time-for-lock duration before killing backends and try upto 3 times.
+  -w, [--wait-time-for-lock=N]                                             # Time to wait before killing backends to acquire lock and/or retrying upto 3 times. It will kill backends if --kill-backends is true, otherwise try upto 3 times and exit if it cannot acquire a lock.
+                                                                           # Default: 10
+  -c, [--copy-statement=COPY_STATEMENT]                                    # Takes a .sql file location where you can provide a custom query to be played (ex: backfills) when pgosc copies data from the primary to the shadow table. More examples in README.
+  -b, [--pull-batch-count=N]                                               # Number of rows to be replayed on each iteration after copy. This can be tuned for faster catch up and swap. Best used with delta-count.
+                                                                           # Default: 1000
+  -e, [--delta-count=N]                                                    # Indicates how many rows should be remaining before a swap should be performed. This can be tuned for faster catch up and swap, especially on highly volume tables. Best used with pull-batch-count.
+                                                                           # Default: 20
+  -o, [--skip-foreign-key-validation], [--no-skip-foreign-key-validation]  # Skip foreign key validation after swap. You shouldn't need this unless you have a very specific use case, like manually validating foreign key constraints after swap.
 ```
 
 ```

--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -89,6 +89,13 @@ module PgOnlineSchemaChange
                   default: DELTA_COUNT,
                   desc:
                     "Indicates how many rows should be remaining before a swap should be performed. This can be tuned for faster catch up and swap, especially on highly volume tables. Best used with pull-batch-count."
+    method_option :skip_foreign_key_validation,
+                  aliases: "-o",
+                  type: :boolean,
+                  required: false,
+                  default: false,
+                  desc:
+                    "Skip foreign key validation after swap. You shouldn't need this unless you have a very specific use case, like manually validating foreign key constraints after swap."
 
     def perform
       client_options = Struct.new(*options.keys.map(&:to_sym)).new(*options.values)

--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -19,7 +19,8 @@ module PgOnlineSchemaChange
                   :wait_time_for_lock,
                   :copy_statement,
                   :pull_batch_count,
-                  :delta_count
+                  :delta_count,
+                  :skip_foreign_key_validation
 
     def initialize(options)
       @alter_statement = options.alter_statement
@@ -34,6 +35,7 @@ module PgOnlineSchemaChange
       @wait_time_for_lock = options.wait_time_for_lock
       @pull_batch_count = options.pull_batch_count
       @delta_count = options.delta_count
+      @skip_foreign_key_validation = options.skip_foreign_key_validation
 
       handle_copy_statement(options.copy_statement)
       handle_validations
@@ -54,7 +56,7 @@ module PgOnlineSchemaChange
 
       return if Query.same_table?(@alter_statement)
 
-      raise Error("All statements should belong to the same table: #{@alter_statement}")
+      raise Error, "All statements should belong to the same table: #{@alter_statement}"
     end
 
     def handle_copy_statement(statement)

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -276,6 +276,8 @@ module PgOnlineSchemaChange
       end
 
       def validate_constraints!
+        return if client.skip_foreign_key_validation
+
         Query
           .get_foreign_keys_to_validate(client, client.table_name)
           .each do |statement|

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -20,6 +20,7 @@ module DatabaseHelpers
       delta_count: 20,
       pull_batch_count: 1000,
       copy_statement: "",
+      skip_foreign_key_validation: false,
     }
     Struct.new(*options.keys).new(*options.values)
   end
@@ -80,7 +81,7 @@ module DatabaseHelpers
         "createdOn" TIMESTAMP NOT NULL,
         last_login TIMESTAMP
       );
-      
+
       CREATE TABLE IF NOT EXISTS #{schema}.this_is_a_table_with_a_very_long_name (
         id serial PRIMARY KEY,
         "createdOn" TIMESTAMP NOT NULL


### PR DESCRIPTION
In case users would like to run the validate constraint post swap manually or keep the constraints in a NO VALID state for older rows, there is now an option to do that with --skip-foreign-key-validation.

Another unrelated bugfix with Error reference class

Related: https://github.com/shayonj/pg-osc/issues/119