### PR TITLE
Introduce the ability to show estimate progress of copy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
         env:
           POSTGRES_USER: jamesbond
           POSTGRES_DB: postgres
+          CI: true
   build-push-image:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7.7"
           - "3.0.5"
           - "3.1.3"
           - "3.2.1"
+          - "3.3.0"
     services:
       postgres:
         image: postgres:9.6.2-alpine

--- a/.github/workflows/smoke-tests-13-6.yaml
+++ b/.github/workflows/smoke-tests-13-6.yaml
@@ -52,3 +52,4 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_PASSWORD: password
           PGPASSWORD: password
+          CI: true

--- a/.github/workflows/smoke-tests-13-6.yaml
+++ b/.github/workflows/smoke-tests-13-6.yaml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7.7"
           - "3.0.5"
           - "3.1.3"
           - "3.2.1"
+          - "3.3.0"
     services:
       postgres:
         image: postgres:13.6-alpine

--- a/.github/workflows/smoke-tests-9-6.yaml
+++ b/.github/workflows/smoke-tests-9-6.yaml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7.7"
           - "3.0.5"
           - "3.1.3"
           - "3.2.1"
+          - "3.3.0"
     services:
       postgres:
         image: postgres:9.6.2-alpine

--- a/.github/workflows/smoke-tests-9-6.yaml
+++ b/.github/workflows/smoke-tests-9-6.yaml
@@ -49,3 +49,4 @@ jobs:
         env:
           POSTGRES_USER: jamesbond
           POSTGRES_DB: postgres
+          CI: true

--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -67,5 +67,9 @@ module PgOnlineSchemaChange
 
       @copy_statement = File.binread(file_path)
     end
+
+    def checkout_connection
+      PG.connect(dbname: dbname, host: host, user: username, password: password, port: port)
+    end
   end
 end

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -301,13 +301,13 @@ module PgOnlineSchemaChange
       def run_analyze!
         logger.info("Performing ANALYZE!")
 
-        Query.run(client.connection, "ANALYZE VERBOSE #{client.table_name};")
+        client.connection.async_exec("ANALYZE VERBOSE #{client.schema}.#{client.table_name};")
       end
 
       def run_vacuum!
         logger.info("Performing VACUUM!")
 
-        Query.run(client.connection, "VACUUM VERBOSE #{client.table_name};")
+        client.connection.async_exec("VACUUM VERBOSE #{client.schema}.#{client.table_name};")
       end
 
       def validate_constraints!

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -88,7 +88,7 @@ module PgOnlineSchemaChange
       def setup_signals!
         reader, writer = IO.pipe
 
-        %w[TERM QUIT INT].each { |sig| trap(sig) { writer.puts sig } }
+        ['TERM', 'QUIT', 'INT'].each { |sig| trap(sig) { writer.puts sig } }
 
         reader
       end

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -5,6 +5,7 @@ require "securerandom"
 module PgOnlineSchemaChange
   class Orchestrate
     SWAP_STATEMENT_TIMEOUT = "5s"
+    TRACK_PROGRESS_INTERVAL = 60 # seconds
 
     extend Helper
 
@@ -58,6 +59,10 @@ module PgOnlineSchemaChange
 
         raise Error, "Parent table has no primary key, exiting..." if primary_key.nil?
 
+        logger.info("Performing some house keeping....")
+        run_analyze!
+        run_vacuum!
+
         setup_audit_table!
 
         setup_trigger!
@@ -83,7 +88,7 @@ module PgOnlineSchemaChange
       def setup_signals!
         reader, writer = IO.pipe
 
-        ['TERM', 'QUIT', 'INT'].each { |sig| trap(sig) { writer.puts sig } }
+        %w[TERM QUIT INT].each { |sig| trap(sig) { writer.puts sig } }
 
         reader
       end
@@ -197,6 +202,25 @@ module PgOnlineSchemaChange
         Store.set(:renamed_columns_list, Query.renamed_columns(client))
       end
 
+      def log_progress
+        new_connection = client.checkout_connection
+        source_table_size = Query.get_table_size(new_connection, client.schema, client.table_name)
+
+        Thread.new do
+          loop do
+            sleep(TRACK_PROGRESS_INTERVAL) unless ENV["CI"]
+
+            shadow_table_size = Query.get_table_size(new_connection, client.schema, shadow_table)
+            progress = (shadow_table_size.to_f / source_table_size) * 100
+            logger.info("Estimated copy progress: #{progress.round(2)}% complete")
+
+            break if @copy_finished || progress >= 100
+          rescue StandardError => e
+            logger.info("Reporting progress failed: #{e.message}")
+          end
+        end
+      end
+
       def copy_data!
         # re-uses transaction with serializable
         # Begin the process to copy data into copy table
@@ -208,19 +232,24 @@ module PgOnlineSchemaChange
         )
         Query.run(client.connection, "DELETE FROM #{audit_table}", true)
 
-        logger.info(
-          "Copying contents..",
-          { shadow_table: shadow_table, parent_table: client.table_name },
-        )
         if client.copy_statement
           query = format(client.copy_statement, shadow_table: shadow_table)
           return Query.run(client.connection, query, true)
         end
 
+        logger.info(
+          "Copying contents..",
+          { shadow_table: shadow_table, parent_table: client.table_name },
+        )
+
+        @copy_finished = false
+        log_progress
+
         sql = Query.copy_data_statement(client, shadow_table, true)
         Query.run(client.connection, sql, true)
       ensure
         Query.run(client.connection, "COMMIT;") # commit the serializable transaction
+        @copy_finished = true
       end
 
       def replay_and_swap!
@@ -273,6 +302,12 @@ module PgOnlineSchemaChange
         logger.info("Performing ANALYZE!")
 
         Query.run(client.connection, "ANALYZE VERBOSE #{client.table_name};")
+      end
+
+      def run_vacuum!
+        logger.info("Performing VACUUM!")
+
+        Query.run(client.connection, "VACUUM VERBOSE #{client.table_name};")
       end
 
       def validate_constraints!

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -428,6 +428,15 @@ module PgOnlineSchemaChange
           SELECT setval((select pg_get_serial_sequence('#{shadow_table}', '#{primary_key}')), (SELECT max(#{primary_key}) FROM #{table}));
         SQL
       end
+
+      def get_table_size(connection, schema, table_name)
+        size_query = "SELECT pg_table_size('#{schema}.#{table_name}');"
+        result = run(connection, size_query).first
+        result["pg_table_size"].to_i
+      rescue StandardError => e
+        logger.error("Error getting table size: #{e.message}")
+        0
+      end
     end
   end
 end

--- a/pg_online_schema_change.gemspec
+++ b/pg_online_schema_change.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary = spec.description
   spec.homepage = "https://github.com/shayonj/pg-osc"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -1535,19 +1535,20 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
         )
         allow(PgOnlineSchemaChange::Orchestrate).to receive(:logger).and_return(logger)
         allow(logger).to receive(:info)
-        allow(Thread).to receive(:new).and_yield
 
-        stub_const("PgOnlineSchemaChange::Orchestrate::TRACK_PROGRESS_INTERVAL", 0)
+        stub_const("PgOnlineSchemaChange::Orchestrate::TRACK_PROGRESS_INTERVAL", 0.1)
+        described_class.instance_variable_set(:@copy_finished, false)
       end
 
       it "logs the estimated copy progress" do
-        allow(client).to receive(:checkout_connection).and_return(client.connection)
-
-        described_class.instance_variable_set(:@copy_finished, true)
-
         expect(logger).to receive(:info).with(/Estimated copy progress: 39.2% complete/)
 
-        described_class.log_progress
+        thread = described_class.log_progress
+
+        sleep(0.2)
+
+        described_class.instance_variable_set(:@copy_finished, true)
+        thread.join
       end
     end
   end

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -989,4 +989,21 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       Process.kill("KILL", pid)
     end
   end
+
+  describe ".get_table_size" do
+    it "returns the table size in bytes" do
+      client = PgOnlineSchemaChange::Client.new(client_options)
+      setup_tables(client)
+      ingest_dummy_data_into_dummy_table(client)
+      result =
+        PgOnlineSchemaChange::Query.get_table_size(
+          client.checkout_connection,
+          client.schema,
+          "books",
+        )
+
+      expect(result).to be_a(Integer)
+      expect(result).to be >= 0
+    end
+  end
 end

--- a/spec/lib/smoke_spec.rb
+++ b/spec/lib/smoke_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe("SmokeSpec") do
       SCRIPT
       result = `#{statement}`
 
+      puts result
+
       expect(result).to match(/All tasks successfully completed/)
       Process.kill("KILL", pid)
 


### PR DESCRIPTION
Introducing a new `log_progress` function to estimate progress during data operations. This function compares the sizes of the parent table and the shadow table using `pg_table_size`. As we can't count the rows directly due to the ongoing transaction, `pg_table_size` provides the closest estimate. Prior to this, we perform a vacuum and analyze on the parent table to enhance the accuracy of the size measurement.

It's important to note that the `pg_table_size` of the shadow table may not exactly match the parent table, especially for larger tables. This discrepancy is expected, since the logging is a best effort measure. The function will terminate once `copy_data` completes as it watches for an instance var - `@copy_finished`

Progress is logged at 60-second intervals.

Lastly, this change also moves the creation of the shadow table outside of the serializable transaction so other connections can see it. 

Towards: https://github.com/shayonj/pg-osc/issues/102