### PR TITLE
Validate delta_count value against pull_batch_count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.idea/
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -112,7 +112,7 @@ module PgOnlineSchemaChange
       PgOnlineSchemaChange::Orchestrate.run!(client_options)
     end
 
-    map %w[--version -v] => :version
+    map ['--version', '-v'] => :version
     desc "--version, -v", "print the version"
 
     def version

--- a/lib/pg_online_schema_change/cli.rb
+++ b/lib/pg_online_schema_change/cli.rb
@@ -112,7 +112,7 @@ module PgOnlineSchemaChange
       PgOnlineSchemaChange::Orchestrate.run!(client_options)
     end
 
-    map ['--version', '-v'] => :version
+    map %w[--version -v] => :version
     desc "--version, -v", "print the version"
 
     def version

--- a/lib/pg_online_schema_change/client.rb
+++ b/lib/pg_online_schema_change/client.rb
@@ -54,6 +54,10 @@ module PgOnlineSchemaChange
         raise Error, "Not a valid ALTER statement: #{@alter_statement}"
       end
 
+      if delta_count > pull_batch_count
+        raise Error, "Value for delta_count should be smaller than the value for pull_batch_count"
+      end
+
       return if Query.same_table?(@alter_statement)
 
       raise Error, "All statements should belong to the same table: #{@alter_statement}"

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe(PgOnlineSchemaChange::Client) do
     )
   end
 
+  it "raises error if delta count is smaller than pull batch count" do
+    options = client_options.to_h.merge(delta_count: 100, pull_batch_count: 50)
+    client_options = Struct.new(*options.keys).new(*options.values)
+    expect { described_class.new(client_options) }.to raise_error(
+      PgOnlineSchemaChange::Error,
+      "Value for delta_count should be smaller than the value for pull_batch_count",
+    )
+  end
+
   describe "handle_copy_statement" do
     it "reads file and sets statement" do
       query = <<~SQL


### PR DESCRIPTION
Validate the value of `delta_count` to be smaller than the `pull_batch_count` value to avoid situations where the replay ends after one cycle and the table is swapped too soon without the full replay completing.