### PR TITLE
Always quote schema names to support uncommon characters like hyphens

### DIFF
--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -16,7 +16,7 @@ module PgOnlineSchemaChange
         sql = <<~SQL
           SET statement_timeout = 0;
           SET client_min_messages = warning;
-          SET search_path TO #{client.schema};
+          SET search_path TO "#{client.schema}";
         SQL
 
         Query.run(client.connection, sql)
@@ -301,13 +301,13 @@ module PgOnlineSchemaChange
       def run_analyze!
         logger.info("Performing ANALYZE!")
 
-        client.connection.async_exec("ANALYZE VERBOSE #{client.schema}.#{client.table_name};")
+        client.connection.async_exec("ANALYZE VERBOSE \"#{client.schema}\".#{client.table_name};")
       end
 
       def run_vacuum!
         logger.info("Performing VACUUM!")
 
-        client.connection.async_exec("VACUUM VERBOSE #{client.schema}.#{client.table_name};")
+        client.connection.async_exec("VACUUM VERBOSE \"#{client.schema}\".#{client.table_name};")
       end
 
       def validate_constraints!

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -328,7 +328,7 @@ module PgOnlineSchemaChange
         run(client.connection, query) do |result|
           definitions =
             result.map do |row|
-              { "#{row["schema_name"]}.#{row["view_name"]}" => row["view_definition"].strip }
+              { "\"#{row["schema_name"]}\".#{row["view_name"]}" => row["view_definition"].strip }
             end
         end
 

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe(PgOnlineSchemaChange::Client) do
     expect(client.alter_statement).to eq(
       "ALTER TABLE books ADD COLUMN \"purchased\" BOOLEAN DEFAULT FALSE;",
     )
-    expect(client.schema).to eq("test_schema")
+    expect(client.schema).to eq("test-schema")
     expect(client.dbname).to eq("postgres")
     expect(client.username).to eq("jamesbond")
     expect(client.port).to eq(5432)

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
         /convalidated AS constraint_validated/,
       ).and_call_original
       expect(client.connection).to receive(:async_exec).with(
-        "SET statement_timeout = 0;\nSET client_min_messages = warning;\nSET search_path TO #{client.schema};\n",
+        "SET statement_timeout = 0;\nSET client_min_messages = warning;\nSET search_path TO \"#{client.schema}\";\n",
       ).and_call_original
       expect(client.connection).to receive(:async_exec).with(
         FUNC_FIX_SERIAL_SEQUENCE,
@@ -283,7 +283,7 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
         select p.oid::regprocedure from pg_proc p
         join pg_namespace n
         on p.pronamespace = n.oid
-        where n.nspname = 'test_schema';
+        where n.nspname = 'test-schema';
       SQL
 
       expect_query_result(
@@ -1382,21 +1382,21 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
     it "succesfully recreates the view" do
       expected_views_result = [
         {
-          "temp_views.books_temp_view" =>
+          "\"temp_views\".books_temp_view" =>
             "SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM books\n  WHERE (books.seller_id = 1);",
         },
         {
-          "test_schema.books_view" =>
+          "\"test-schema\".books_view" =>
             "SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM books\n  WHERE (books.seller_id = 1);",
         },
       ]
       expected_views_result_op_table = [
         {
-          "temp_views.books_temp_view" =>
+          "\"temp_views\".books_temp_view" =>
             "SELECT pgosc_op_table_books.user_id,\n    pgosc_op_table_books.username,\n    pgosc_op_table_books.seller_id,\n    pgosc_op_table_books.password,\n    pgosc_op_table_books.email,\n    pgosc_op_table_books.\"createdOn\",\n    pgosc_op_table_books.last_login\n   FROM pgosc_op_table_books\n  WHERE (pgosc_op_table_books.seller_id = 1);",
         },
         {
-          "test_schema.books_view" =>
+          "\"test-schema\".books_view" =>
             "SELECT pgosc_op_table_books.user_id,\n    pgosc_op_table_books.username,\n    pgosc_op_table_books.seller_id,\n    pgosc_op_table_books.password,\n    pgosc_op_table_books.email,\n    pgosc_op_table_books.\"createdOn\",\n    pgosc_op_table_books.last_login\n   FROM pgosc_op_table_books\n  WHERE (pgosc_op_table_books.seller_id = 1);",
         },
       ]

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -538,9 +538,9 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       result = described_class.get_indexes_for(client, "books")
       expect(result).to eq(
         [
-          "CREATE UNIQUE INDEX books_pkey ON #{client.schema}.books USING btree (user_id)",
-          "CREATE UNIQUE INDEX books_username_key ON #{client.schema}.books USING btree (username)",
-          "CREATE UNIQUE INDEX books_email_key ON #{client.schema}.books USING btree (email)",
+          "CREATE UNIQUE INDEX books_pkey ON \"#{client.schema}\".books USING btree (user_id)",
+          "CREATE UNIQUE INDEX books_username_key ON \"#{client.schema}\".books USING btree (username)",
+          "CREATE UNIQUE INDEX books_email_key ON \"#{client.schema}\".books USING btree (email)",
         ],
       )
     end
@@ -701,12 +701,12 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       expect(result).to eq(
         [
           {
-            "temp_views.books_temp_view" =>
-              "SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM test_schema.books\n  WHERE (books.seller_id = 1);",
+            "\"temp_views\".books_temp_view" =>
+              "SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM \"test-schema\".books\n  WHERE (books.seller_id = 1);",
           },
           {
-            "test_schema.books_view" =>
-              "SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM test_schema.books\n  WHERE (books.seller_id = 1);",
+            "\"test-schema\".books_view" =>
+              "SELECT books.user_id,\n    books.username,\n    books.seller_id,\n    books.password,\n    books.email,\n    books.\"createdOn\",\n    books.last_login\n   FROM \"test-schema\".books\n  WHERE (books.seller_id = 1);",
           },
         ],
       )
@@ -845,7 +845,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
           new_client = PgOnlineSchemaChange::Client.new(client_options)
           setup_tables(new_client)
           new_client.connection.async_exec(
-            "SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;",
+            "SET search_path to \"#{new_client.schema}\"; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;",
           )
 
           sleep(50)
@@ -860,7 +860,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       client_options = Struct.new(*options.keys).new(*options.values)
       client = PgOnlineSchemaChange::Client.new(client_options)
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-      client.connection.async_exec("SET search_path to #{client.schema};")
+      client.connection.async_exec("SET search_path to \"#{client.schema}\";")
 
       sleep 0.5
 
@@ -879,7 +879,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
           new_client = PgOnlineSchemaChange::Client.new(client_options)
           setup_tables(new_client)
           new_client.connection.async_exec(
-            "SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;",
+            "SET search_path to \"#{new_client.schema}\"; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;",
           )
 
           sleep(50)
@@ -891,7 +891,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
 
       client = PgOnlineSchemaChange::Client.new(client_options)
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-      client.connection.async_exec("SET search_path to #{client.schema};")
+      client.connection.async_exec("SET search_path to \"#{client.schema}\";")
 
       sleep(0.5)
 
@@ -911,7 +911,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
           new_client = PgOnlineSchemaChange::Client.new(client_options)
           setup_tables(new_client)
           new_client.connection.async_exec(
-            "SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;",
+            "SET search_path to \"#{new_client.schema}\"; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;",
           )
 
           sleep(10)
@@ -923,7 +923,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
 
       client = PgOnlineSchemaChange::Client.new(client_options)
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
-      client.connection.async_exec("SET search_path to #{client.schema};")
+      client.connection.async_exec("SET search_path to \"#{client.schema}\";")
 
       sleep 0.5
 
@@ -951,7 +951,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       client = PgOnlineSchemaChange::Client.new(client_options)
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
 
-      client.connection.async_exec("SET search_path to #{client.schema};")
+      client.connection.async_exec("SET search_path to \"#{client.schema}\";")
       result = described_class.kill_backends(client, client.table).map { |n| n }
       expect(result.first).to be_nil
     end
@@ -964,7 +964,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
           new_client = PgOnlineSchemaChange::Client.new(client_options)
           setup_tables(new_client)
           new_client.connection.async_exec(
-            "SET search_path to #{new_client.schema}; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;",
+            "SET search_path to \"#{new_client.schema}\"; BEGIN; LOCK TABLE #{new_client.table_name} IN ACCESS EXCLUSIVE MODE;",
           )
 
           sleep(5)
@@ -980,7 +980,7 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       client = PgOnlineSchemaChange::Client.new(client_options)
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
 
-      client.connection.async_exec("SET search_path to #{client.schema};")
+      client.connection.async_exec("SET search_path to \"#{client.schema}\";")
 
       result = described_class.kill_backends(client, client.table).map { |n| n }
 


### PR DESCRIPTION
Hello,

This is a combination bug report and proof-of-concept pull request looking for feedback. :slightly_smiling_face: 

**Problem:** It looks like pg-osc assumes that schema names will be safe to remain [unquoted](hhttps://www.postgresql.org/docs/17/sql-syntax-lexical.html). However, given a schema name that includes, say, hyphens, like `test-schema` (instead of `test_schema`), there are naturally syntax errors due to `test-schema` being used unquoted.

**No workaround:** Passing a quoted schema name as input in the CLI, like `"test-schema"`, also does not work, because the quotation does not fit in value positions where it might have to get unquoted.

**Proposal:** This PR adds quoting to all usages of the schema name as an identifier. That should work for names like `test-schema` as well as remain backward compatible with typical unquoted-safe names like `test_schema`. So to ensure regression coverage, the default spec schema is changed to `test-schema`.

**Side effects:** This change also supports case variations in schema names. That may mean that users who might have been used to upper-casing unquoted names like `CREATE SCHEMA FOOBAR` and passing a corresponding input schema name like `FOOBAR` will have to start lower-casing the pg-osc input schema name as `foobar`.

**Out of scope:** Other identifiers like table names are out of scope here.

**Testing:** Tested with the RSpec suite, but it would be worth manually testing further.