### PR TITLE
chore: perserve original indexes, constraints, sequences names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       google-protobuf (= 3.25.5)
       ougai (~> 2.0.0)
       pg (>= 1.3.2, < 1.6.0)
-      pg_query (>= 2.1.3, < 4.3.0)
+      pg_query (>= 5.2)
       thor (>= 1.2.1, < 1.4.0)
 
 GEM
@@ -36,8 +36,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.8)
-    pg_query (4.2.3)
-      google-protobuf (>= 3.22.3)
+    pg_query (6.1.0)
+      google-protobuf (>= 3.25.3)
     prettier_print (1.2.1)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -111,6 +111,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 version: "2"
 services:
   postgres:
-    image: postgres:9.6.2-alpine
+    image: postgres:13.8-alpine
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_USER: jamesbond
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres

--- a/lib/pg_online_schema_change/orchestrate.rb
+++ b/lib/pg_online_schema_change/orchestrate.rb
@@ -51,6 +51,9 @@ module PgOnlineSchemaChange
           Query.self_foreign_keys_to_refresh(client, client.table_name),
         )
         Store.set(:trigger_statements, Query.get_triggers_for(client, client.table_name))
+        Store.set(:original_indexes, Query.get_indexes_for(client, client.table_name))
+        Store.set(:original_sequences, Query.get_sequences_for(client, client.table_name))
+        Store.set(:original_constraints, Query.get_constraints_for(client, client.table_name))
       end
 
       def run!(options)
@@ -75,6 +78,7 @@ module PgOnlineSchemaChange
         validate_constraints!
         replace_views!
         drop_and_cleanup!
+        restore_original_names!
 
         logger.info("All tasks successfully completed")
       rescue StandardError => e
@@ -352,6 +356,126 @@ module PgOnlineSchemaChange
         SQL
 
         Query.run(client.connection, sql)
+      end
+
+      def restore_original_names!
+        logger.info("Restoring original index, constraint, and sequence names")
+        
+        restore_original_indexes!
+        restore_original_constraints!
+        restore_original_sequences!
+        
+        logger.info("Restoration completed successfully ✅")
+      end
+      
+      def restore_original_sequences!
+        logger.info("Restoring sequence names...")
+      
+        original_sequences = Store.get(:original_sequences) || []
+        logger.info("original_sequences", data: original_sequences)
+      
+        current_sequences = Query.get_sequences_for(client, client.table_name)
+        logger.info("current_sequences", data: current_sequences)
+      
+        original_sequences.each do |original_seq|
+          original_seq_name = original_seq["sequence_name"]
+          next unless original_seq_name # skip if nil
+      
+          # Find the matching current sequence
+          matching = current_sequences.find do |curr|
+            curr["column_name"] == original_seq["column_name"] && curr["table_name"] == client.table_name
+          end
+      
+          next unless matching
+      
+          current_seq_name = matching["sequence_name"]
+      
+          logger.info("Renaming sequence #{current_seq_name} to #{original_seq_name}")
+      
+          sql = <<~SQL
+            ALTER SEQUENCE IF EXISTS #{current_seq_name} RENAME TO #{original_seq_name};
+          SQL
+          Query.run(client.connection, sql)
+        end
+      end          
+
+      def restore_original_indexes!
+        logger.info("Restoring index names...")
+      
+        original_indexes = Store.get(:original_indexes) || []
+        current_indexes = Query.get_indexes_for(client, client.table_name)
+      
+        original_indexes.each do |original_index|
+          orig_index_name = original_index["indexname"]
+      
+          # Find the matching current index by definition
+          matching = current_indexes.find do |curr|
+            # Match the column definition (ignore index name)
+            # Compare definition parts (e.g., columns used)
+            curr_def = curr["indexdef"].gsub(/INDEX \S+ ON \S+ USING/, "").strip
+            orig_def = original_index["indexdef"].gsub(/INDEX \S+ ON \S+ USING/, "").strip
+            curr_def == orig_def
+          end
+      
+          unless matching
+            logger.warn("Could not find matching index for #{orig_index_name}, skipping")
+            next
+          end
+      
+          current_index_name = matching["indexname"]
+      
+          # Skip if names already match
+          if current_index_name == orig_index_name
+            logger.info("Index #{orig_index_name} already correct, skipping")
+            next
+          end
+      
+          logger.info("Renaming index #{current_index_name} to #{orig_index_name}")
+      
+          sql = <<~SQL
+            ALTER INDEX IF EXISTS "#{current_index_name}" RENAME TO "#{orig_index_name}";
+          SQL
+          Query.run(client.connection, sql)
+        end
+      end      
+      
+      def restore_original_constraints!
+        logger.info("Restoring constraint names...")
+      
+        original_constraints = Store.get(:original_constraints) || []
+        current_constraints = Query.get_constraints_for(client, client.table_name)
+      
+        original_constraints.each do |original_constraint|
+          orig_constraint_name = original_constraint["constraint_name"]
+      
+          # Skip if primary key, already restored during index restoration
+          next if original_constraint["constraint_type"] == "p"
+      
+          # Find the matching constraint after swap
+          matching = current_constraints.find do |curr|
+            curr["definition"] == original_constraint["definition"]
+          end
+      
+          unless matching
+            logger.warn("Could not find matching constraint for #{orig_constraint_name}, skipping")
+            next
+          end
+      
+          current_constraint_name = matching["constraint_name"]
+      
+          # Skip if names already match
+          if current_constraint_name == orig_constraint_name
+            logger.info("Constraint #{orig_constraint_name} already correct, skipping")
+            next
+          end
+      
+          logger.info("Renaming constraint #{current_constraint_name} to #{orig_constraint_name}")
+      
+          sql = <<~SQL
+            ALTER TABLE "#{client.table_name}" RENAME CONSTRAINT "#{current_constraint_name}" TO "#{orig_constraint_name}";
+          SQL
+          Query.run(client.connection, sql)
+        end
       end
 
       private

--- a/lib/pg_online_schema_change/query.rb
+++ b/lib/pg_online_schema_change/query.rb
@@ -121,19 +121,6 @@ module PgOnlineSchemaChange
         parsed_query.deparse
       end
 
-      def get_indexes_for(client, table)
-        query = <<~SQL
-          SELECT indexdef, schemaname
-          FROM pg_indexes
-          WHERE schemaname = '#{client.schema}' AND tablename = '#{table}'
-        SQL
-
-        indexes = []
-        run(client.connection, query) { |result| indexes = result.map { |row| row["indexdef"] } }
-
-        indexes
-      end
-
       # fetches the sequence name of a table and column combination
       def get_sequence_name(client, table, column)
         query = <<~SQL
@@ -403,7 +390,7 @@ module PgOnlineSchemaChange
         select_columns.map! { |select_column| client.connection.quote_ident(select_column) }
 
         <<~SQL
-          INSERT INTO #{shadow_table}(#{insert_into_columns.join(", ")})
+          INSERT INTO #{shadow_table}(#{insert_into_columns.join(", ")}) OVERRIDING SYSTEM VALUE
           SELECT #{select_columns.join(", ")}
           FROM ONLY #{client.table_name}
         SQL
@@ -437,6 +424,61 @@ module PgOnlineSchemaChange
         logger.error("Error getting table size: #{e.message}")
         0
       end
+
+      def get_indexes_for(client, table)
+        query = <<~SQL
+          SELECT indexname, indexdef
+          FROM pg_indexes
+          WHERE schemaname = '#{client.schema}'
+          AND tablename = '#{table}'
+        SQL
+      
+        indexes = []
+        run(client.connection, query) { |result| indexes = result.map { |row| row } }
+        indexes
+      end
+
+      def get_sequences_for(client, table)
+        query = <<~SQL
+          SELECT
+            ns.nspname AS schema_name,
+            seq.relname AS sequence_name,
+            tbl.relname AS table_name,
+            col.attname AS column_name
+          FROM
+            pg_class seq
+            JOIN pg_namespace ns ON seq.relnamespace = ns.oid
+            JOIN pg_depend d ON seq.oid = d.objid
+            JOIN pg_class tbl ON d.refobjid = tbl.oid
+            JOIN pg_attribute col ON col.attrelid = tbl.oid AND col.attnum = d.refobjsubid
+          WHERE
+            seq.relkind = 'S'
+            AND tbl.relname = '#{table}'
+            AND ns.nspname = '#{client.schema}'
+        SQL
+      
+        sequences = []
+        run(client.connection, query) { |result| sequences = result.map { |row| row } }
+        sequences
+      end          
+      
+      def get_constraints_for(client, table)
+        query = <<~SQL
+          SELECT
+            conname AS constraint_name,
+            contype AS constraint_type,
+            conrelid::regclass::text AS table_on,
+            confrelid::regclass::text AS table_from,
+            pg_get_constraintdef(oid) AS definition
+          FROM pg_constraint
+          WHERE connamespace = (SELECT oid FROM pg_namespace WHERE nspname = '#{client.schema}')
+            AND conrelid = '#{table}'::regclass
+        SQL
+      
+        constraints = []
+        run(client.connection, query) { |result| constraints = result.map { |row| row } }
+        constraints
+      end      
     end
   end
 end

--- a/pg_online_schema_change.gemspec
+++ b/pg_online_schema_change.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("google-protobuf", "3.25.5")
   spec.add_runtime_dependency("ougai", "~> 2.0.0")
   spec.add_runtime_dependency("pg", ">= 1.3.2", "< 1.6.0")
-  spec.add_runtime_dependency("pg_query", ">= 2.1.3", "< 4.3.0")
+  spec.add_runtime_dependency("pg_query", ">= 5.2")
   spec.add_runtime_dependency("thor", ">= 1.2.1", "< 1.4.0")
 
   spec.add_development_dependency("prettier_print")

--- a/spec/lib/orchestrate_spec.rb
+++ b/spec/lib/orchestrate_spec.rb
@@ -449,16 +449,17 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
         ],
       )
 
-      columns =
-        PgOnlineSchemaChange::Query.get_indexes_for(client, described_class.shadow_table.to_s)
-      expect(columns).to eq(
+      columns = PgOnlineSchemaChange::Query.get_indexes_for(client, described_class.shadow_table.to_s)
+      index_defs = columns.map { |col| col["indexdef"] }
+      
+      expect(index_defs).to eq(
         [
           "CREATE UNIQUE INDEX #{described_class.shadow_table}_pkey ON #{described_class.shadow_table} USING btree (user_id)",
           "CREATE UNIQUE INDEX #{described_class.shadow_table}_username_key ON #{described_class.shadow_table} USING btree (username)",
           "CREATE UNIQUE INDEX #{described_class.shadow_table}_email_key ON #{described_class.shadow_table} USING btree (email)",
-        ],
+        ]
       )
-
+      
       foreign_keys =
         PgOnlineSchemaChange::Query.get_foreign_keys_for(client, described_class.shadow_table.to_s)
       expect(foreign_keys).to eq([])
@@ -1030,7 +1031,9 @@ RSpec.describe(PgOnlineSchemaChange::Orchestrate) do
 
       # confirm indexes on newly renamed table
       columns = PgOnlineSchemaChange::Query.get_indexes_for(client, "books")
-      expect(columns).to eq(
+      index_defs = columns.map { |col| col["indexdef"] }
+
+      expect(index_defs).to eq(
         [
           "CREATE UNIQUE INDEX #{described_class.shadow_table}_pkey ON books USING btree (user_id)",
           "CREATE UNIQUE INDEX #{described_class.shadow_table}_username_key ON books USING btree (username)",

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -523,20 +523,23 @@ RSpec.describe(PgOnlineSchemaChange::Query) do
       allow(PgOnlineSchemaChange::Client).to receive(:new).and_return(client)
       client
     end
-
-    it "returns index statements for the given table on client" do
+  
+    it "returns index definitions for the given table on client" do
       query = <<~SQL
-        SELECT indexdef, schemaname
+        SELECT indexname, indexdef
         FROM pg_indexes
         WHERE schemaname = '#{client.schema}' AND tablename = 'books'
       SQL
-
+  
       expect(client.connection).to receive(:async_exec).with("BEGIN;").and_call_original
       expect(client.connection).to receive(:async_exec).with(query).and_call_original
       expect(client.connection).to receive(:async_exec).with("COMMIT;").and_call_original
-
+  
       result = described_class.get_indexes_for(client, "books")
-      expect(result).to eq(
+  
+      index_defs = result.map { |r| r["indexdef"] }
+  
+      expect(index_defs).to eq(
         [
           "CREATE UNIQUE INDEX books_pkey ON \"#{client.schema}\".books USING btree (user_id)",
           "CREATE UNIQUE INDEX books_username_key ON \"#{client.schema}\".books USING btree (username)",


### PR DESCRIPTION
### Context:

This PR ensures that original names of indexes, constraints, and sequences are preserved after performing an online schema change.

Previously, after the swap, the new shadow table kept temporary names generated during the migration (e.g., pgosc_st_users_xxxx_pkey, pgosc_st_users_xxxx_email_idx, etc.).
This led to inconsistencies between the old and new schema, and could cause issues in applications, ORM models, or scripts relying on the original names.

This PR addresses that by:

- Capturing all original indexes, constraints, and sequences before the schema change starts.
- After the swap:
  - Renaming all indexes back to their original names.
  - Renaming all constraints (primary keys and others) back to their original names.
  - Renaming all sequences back to their original names.
- Ensuring seamless migration without breaking any dependency on object names.

### Why OVERRIDING SYSTEM VALUE was added ?
When copying data to the shadow table, identity columns (GENERATED ALWAYS) would block inserts.
Adding OVERRIDING SYSTEM VALUE allows inserting explicit values into identity columns, preserving original IDs during migration.

### What's included?

- restore_original_indexes!: Renames indexes to their original names.
- restore_original_constraints!: Renames all constraints to original names.
- restore_original_sequences!: Renames sequences to original names.
- Updates to orchestration flow to call restore_original_names! automatically after swap.
- Add OVERRIDING SYSTEM VALUE to support identity columns during copy.